### PR TITLE
Support Azure OpenAI endpoint across the repo with it as the default; improve error handling and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# ============================================================
+# AgentRx Environment Configuration
+# ============================================================
+# Copy this file to .env and fill in your values:
+
+
+# ----------------------------------------------------------
+# Default endpoint type: "azure" or "trapi" (override per-command with --endpoint)
+# Both endpoints use Azure AD token auth (run `az login` first)
+# ----------------------------------------------------------
+AGENT_VERIFY_ENDPOINT_TYPE=azure
+
+# ----------------------------------------------------------
+# Azure OpenAI endpoint (default)
+# ----------------------------------------------------------
+AGENT_VERIFY_ENDPOINT=                # e.g. https://my-resource.openai.azure.com/
+AGENT_VERIFY_DEPLOYMENT=gpt-5         # model deployment name
+AGENT_VERIFY_API_VERSION=2024-12-01-preview
+AGENT_VERIFY_CLIENT_ID=               # Managed Identity client ID (if applicable)
+
+# ----------------------------------------------------------
+# TRAPI endpoint (Microsoft Research internal, use --endpoint trapi)
+# See https://aka.ms/trapi/models for instance and deployment names.
+# ----------------------------------------------------------
+AGENT_VERIFY_TRAPI_INSTANCE=          # e.g. my-instance/my-pool
+AGENT_VERIFY_TRAPI_DEPLOYMENT_NAME=   # e.g. gpt-5
+SCOPE=                                # Azure AD scope for TRAPI

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__/
 .env
-.env.example
 runs/
 src/invariants/dynamic_invariant_outputs/
+papers/
+related_works.md
+partners/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Raw logs ──▶ Trajectory IR ──▶ Invariants ──▶ Checker ──�
 ## Quick Start
 
 ```bash
+# Setup
+python -m venv .venv
+.venv/Scripts/activate          # Windows; use `source .venv/bin/activate` on Linux/Mac
 pip install -r requirements.txt
+cp .env.example .env            # Fill in your Azure or TRAPI endpoint detailsdetails
 
 # Run the full pipeline end-to-end
 python run.py trajectory.json
@@ -103,17 +107,25 @@ agentverify/
 
 LLM settings are loaded from environment variables (via `.env` or shell):
 
+Copy the template and fill in your values:
 ```bash
-# TRAPI (default endpoint)
-AGENT_VERIFY_TRAPI_INSTANCE=          # e.g., "my-instance/my-pool"
-AGENT_VERIFY_TRAPI_DEPLOYMENT_NAME=   # e.g., "my-deployment-name"
+cp .env.example .env
+```
 
-# Azure OpenAI (use --endpoint azure)
+```bash
+# Azure OpenAI (default endpoint)
 AGENT_VERIFY_ENDPOINT=                # e.g., "https://my-resource.openai.azure.com/"
 AGENT_VERIFY_DEPLOYMENT=              # e.g., "gpt-5"
+
+# TRAPI (Microsoft Research internal, use --endpoint trapi)
+AGENT_VERIFY_TRAPI_INSTANCE=          # e.g., "my-instance/my-pool"
+AGENT_VERIFY_TRAPI_DEPLOYMENT_NAME=   # e.g., "my-deployment-name"
+SCOPE=                                # Azure AD scope for TRAPI
 ```
 
 Both endpoints use **Azure AD token-based auth** (`az login` or Managed Identity).
+
+> **Note:** TRAPI is a Microsoft Research internal endpoint. External teams should use `--endpoint azure` (default).
 
 ---
 
@@ -140,7 +152,7 @@ Each module can also be run standalone from `src/`:
 
 **Static Invariant Generator** — generate policy/tool invariants:
 ```bash
-python src/invariants/static_invariant_generator.py --input-path trajectory.json --domain tau --endpoint trapi
+python src/invariants/static_invariant_generator.py --input-path trajectory.json --domain tau
 ```
 
 **Dynamic Invariant Generator** — generate per-step context-aware invariants:
@@ -155,7 +167,7 @@ python src/invariants/checker.py --input-path trajectory.json --static-invariant
 
 **Judge** — run LLM-as-a-Judge classification:
 ```bash
-python src/judge/judge.py --domain tau --log_file trajectory.json --endpoint trapi --mode combined
+python src/judge/judge.py --domain tau --log_file trajectory.json --mode combined
 ```
 
 ---
@@ -171,6 +183,19 @@ This project uses the following third-party open source packages (installed via 
 - **httpx** — HTTP client (BSD License)
 
 See [requirements.txt](requirements.txt) for the full list of dependencies.
+
+---
+
+## Troubleshooting
+
+### `DefaultAzureCredential` timeout on local machines
+
+The Azure SDK's `DefaultAzureCredential` tries `ManagedIdentityCredential` before `AzureCliCredential`. On a local dev machine this probes the IMDS endpoint which doesn't exist locally, causing a ~5-10s timeout before falling back. This is a [known Azure SDK issue](https://github.com/Azure/azure-sdk-for-python/issues/35452).
+
+**Workaround:** retry (the token gets cached), or warm the cache first:
+```bash
+.venv/Scripts/python -c "from azure.identity import AzureCliCredential; AzureCliCredential().get_token('https://cognitiveservices.azure.com/.default'); print('Token cached')"
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Raw logs ──▶ Trajectory IR ──▶ Invariants ──▶ Checker ──�
 python -m venv .venv
 .venv/Scripts/activate          # Windows; use `source .venv/bin/activate` on Linux/Mac
 pip install -r requirements.txt
-cp .env.example .env            # Fill in your Azure or TRAPI endpoint detailsdetails
+cp .env.example .env            # Fill in your Azure or TRAPI endpoint details
 
 # Run the full pipeline end-to-end
 python run.py trajectory.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# Development / testing
+pytest>=9.0
+
 # Core dependencies actually used by AgentRx
 azure-ai-inference>=1.0.0b9
 azure-core>=1.38.0

--- a/run.py
+++ b/run.py
@@ -35,6 +35,8 @@ REPO_ROOT = Path(__file__).resolve().parent
 SRC_DIR = REPO_ROOT / "src"
 sys.path.insert(0, str(SRC_DIR))
 
+import pipeline.globals as g
+
 # ---------- Stage definitions ----------
 
 STAGES = ["ir", "static", "dynamic", "check", "judge", "report"]
@@ -91,9 +93,34 @@ def banner(msg: str):
     print(f"{'=' * width}\n")
 
 
+def validate_endpoint_config(endpoint: str):
+    """Validate that required environment variables are set for the chosen endpoint."""
+    missing = []
+    if endpoint == "trapi":
+        if not g.TRAPI_INSTANCE:
+            missing.append("AGENT_VERIFY_TRAPI_INSTANCE")
+        if not g.TRAPI_DEPLOYMENT_NAME:
+            missing.append("AGENT_VERIFY_TRAPI_DEPLOYMENT_NAME")
+        if not os.environ.get("SCOPE", ""):
+            missing.append("SCOPE")
+    elif endpoint == "azure":
+        if not g.ENDPOINT:
+            missing.append("AGENT_VERIFY_ENDPOINT")
+    else:
+        print(f"\nError: Unknown endpoint '{endpoint}'. Must be 'azure' or 'trapi'.")
+        sys.exit(1)
+
+    if missing:
+        print(f"\nError: Missing required environment variables for --endpoint {endpoint}:")
+        for v in missing:
+            print(f"  - {v}")
+        print(f"\nSee .env.example for a template: cp .env.example .env")
+        sys.exit(1)
+
+
 # ---------- Stage: IR ----------
 
-def run_ir(input_path: str, run_dir: str, domain: str, state: dict) -> str:
+def run_ir(input_path: str, run_dir: str, domain: str, endpoint: str, state: dict) -> str:
     """Normalize trajectory to IR format. Returns path to IR output."""
     from ir.trajectory_ir import load_trajectories, validate_ir
     from invariants.domain_registry import get_domain_config
@@ -115,7 +142,7 @@ def run_ir(input_path: str, run_dir: str, domain: str, state: dict) -> str:
     if _is_degenerate_ir(data, input_path):
         print("  [INFO] Domain converter produced degenerate IR — falling back to LLM-based converter")
         from ir.trajectory_ir import llm_ir
-        data = llm_ir(raw)
+        data = llm_ir(raw, endpoint=endpoint)
         if not isinstance(data, list):
             data = [data]
         used_llm_fallback = True
@@ -426,7 +453,7 @@ def guess_domain(input_path: str) -> str:
     except Exception:
         pass
 
-    # Default to LLM-based IR (flash uses a reasonable default pipeline)
+    # Default to flash (uses LLM-based IR fallback for unknown formats)
     return "flash"
 
 
@@ -444,7 +471,7 @@ Examples:
   python run.py data/my_trajectory.json --from-stage check   # resume from checking
   python run.py data/my_trajectory.json --skip-dynamic       # faster, no per-step invariants
   python run.py data/my_trajectory.json --skip-judge         # skip LLM judge
-  python run.py data/my_trajectory.json --endpoint trapi     # use TRAPI instead of Azure
+  python run.py data/my_trajectory.json --endpoint trapi     # use TRAPI (Microsoft Research internal)
   python run.py data/my_trajectory.json --run-name my_run    # custom run name
         """,
     )
@@ -452,8 +479,8 @@ Examples:
     parser.add_argument("--domain", default=None,
                         choices=["tau", "flash", "magentic"],
                         help="Domain (auto-detected if not specified)")
-    parser.add_argument("--endpoint", default="trapi", choices=["azure", "trapi"],
-                        help="LLM endpoint (default: trapi)")
+    parser.add_argument("--endpoint", default=g.DEFAULT_ENDPOINT, choices=["azure", "trapi"],
+                        help="LLM endpoint (default: azure). TRAPI is Microsoft Research internal.")
     parser.add_argument("--stage", default=None, choices=STAGES,
                         help="Run ONLY this stage")
     parser.add_argument("--from-stage", default=None, choices=STAGES,
@@ -478,6 +505,9 @@ Examples:
     # Detect domain
     domain = args.domain or guess_domain(input_path)
     print(f"Domain: {domain}")
+
+    # Validate endpoint config before doing any work
+    validate_endpoint_config(args.endpoint)
 
     # Set up run directory
     if args.run_dir:
@@ -532,12 +562,12 @@ Examples:
     try:
         # --- IR ---
         if "ir" in stages_to_run:
-            ir_path = run_ir(input_path, run_dir, domain, state)
+            ir_path = run_ir(input_path, run_dir, domain, args.endpoint, state)
             state["completed_stages"] = list(set(state.get("completed_stages", [])) | {"ir"})
             save_state(run_dir, state)
         elif not os.path.exists(ir_path):
             print("[INFO] Running IR stage (required by later stages)")
-            ir_path = run_ir(input_path, run_dir, domain, state)
+            ir_path = run_ir(input_path, run_dir, domain, args.endpoint, state)
             state["completed_stages"] = list(set(state.get("completed_stages", [])) | {"ir"})
             save_state(run_dir, state)
 

--- a/src/invariants/checker.py
+++ b/src/invariants/checker.py
@@ -917,6 +917,11 @@ class AllVerifier:
 
         except Exception as e:
             end = time.perf_counter()
+            if "context_length_exceeded" in str(e):
+                raise RuntimeError(
+                    f"NL check prompt too large for the model's context window. "
+                    f"Use a model with a larger context limit or set SKIP_NL=1.\n{e}"
+                )
 
             tb = traceback.format_exc()
             if DEBUG_NL_PROMPTS and focus_inv(invariant):
@@ -1065,7 +1070,7 @@ def main():
         dest="client",
         help="Use TRAPI client"
     )
-    parser.set_defaults(client="azure")
+    parser.set_defaults(client=g.DEFAULT_ENDPOINT)
     parser.add_argument("--domain", type=str, default="flash",
                         choices=["flash", "tau", "magentic"],
                         help="Domain to run (default: flash)")

--- a/src/invariants/dynamic_invariant_generator.py
+++ b/src/invariants/dynamic_invariant_generator.py
@@ -46,7 +46,7 @@ CLI flags:
   --input-path PATH                 Trajectory file or directory of .json/.jsonl files
   --out-dir DIR                     Output directory (default: dynamic_invariant_outputs)
   --static-invariants PATH          Path to static invariants JSON
-  --endpoint {trapi,azure}          LLM endpoint (default: trapi)
+  --endpoint {azure,trapi}          LLM endpoint (default: azure)
   --include-nl-check / --no-nl-check  Enable/disable NL check invariants (default: enabled)
 
 Also importable for the larger pipeline:
@@ -1832,7 +1832,7 @@ class DynamicInvariantGenerator:
         tools_list: Optional[List[str]] = None,
         tools_structure: Optional[Union[dict, str]] = None,
         include_nl_check: bool = True,
-        endpoint: str = "trapi",
+        endpoint: str = "azure",
     ) -> None:
         self.out_dir = abspath_rel(out_dir)
         ensure_dir(self.out_dir)
@@ -1950,12 +1950,19 @@ class DynamicInvariantGenerator:
 
                 dynamic_generation_start_timestamp = datetime.datetime.now()
                 dynamic_generation_start = time.perf_counter()
-                response = self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=[{"role": "user", "content": prompt}],
-                    response_format={"type": "json_object"},
-                )
-
+                try:
+                    response = self.client.chat.completions.create(
+                        model=self.model_name,
+                        messages=[{"role": "user", "content": prompt}],
+                        response_format={"type": "json_object"},
+                    )
+                except Exception as e:
+                    if "context_length_exceeded" in str(e):
+                        raise RuntimeError(
+                            f"Step {step_num} prompt too large for the model's context window. "
+                            f"Use a model with a larger context limit.\n{e}"
+                        )
+                    raise
 
                 dynamic_generation_end = time.perf_counter()
                 dynamic_generation_end_timestamp = datetime.datetime.now()
@@ -2115,7 +2122,7 @@ class OneShotDynamicInvariantGenerator:
         tools_list: Optional[List[str]] = None,
         tools_structure: Optional[Union[dict, str]] = None,
         include_nl_check: bool = False,
-        endpoint: str = "trapi",
+        endpoint: str = "azure",
     ) -> None:
         self.out_dir = abspath_rel(out_dir)
         ensure_dir(self.out_dir)
@@ -2202,11 +2209,19 @@ class OneShotDynamicInvariantGenerator:
             start_ts = datetime.datetime.now()
             start = time.perf_counter()
 
-            response = self.client.chat.completions.create(
-                model=self.model_name,
-                messages=[{"role": "user", "content": prompt}],
-                response_format={"type": "json_object"},
-            )
+            try:
+                response = self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=[{"role": "user", "content": prompt}],
+                    response_format={"type": "json_object"},
+                )
+            except Exception as e:
+                if "context_length_exceeded" in str(e):
+                    raise RuntimeError(
+                        f"Trajectory too large for the model's context window. "
+                        f"Use a model with a larger context limit.\n{e}"
+                    )
+                raise
 
             end = time.perf_counter()
             end_ts = datetime.datetime.now()
@@ -2559,9 +2574,9 @@ if __name__ == "__main__":
                         help="Output directory for dynamic invariants")
     parser.add_argument("--static-invariants", type=str, default=None,
                         help="Path to static invariants JSON file")
-    parser.add_argument("--endpoint", type=str, default="trapi",
+    parser.add_argument("--endpoint", type=str, default=g.DEFAULT_ENDPOINT,
                         choices=["azure", "trapi"],
-                        help="LLM endpoint to use (default: trapi)")
+                        help="LLM endpoint to use (default: azure)")
     grp = parser.add_mutually_exclusive_group()
     parser.set_defaults(include_nl_check=True)
     grp.add_argument("--include-nl-check", dest="include_nl_check", action="store_true")

--- a/src/invariants/static_invariant_generator.py
+++ b/src/invariants/static_invariant_generator.py
@@ -10,19 +10,19 @@ Supports python_check only or python_check + nl_check (via --include-nl-check)
 
 Usage (run from src/ directory):
   # Tau-retail (python-only invariants, default):
-  python -m invariants.static_invariant_generator --domain tau --input-path ../trajectories/tau-retail/instruction_adherence_failure.json --out-path out/static_tau.json --endpoint trapi
+  python -m invariants.static_invariant_generator --domain tau --input-path ../trajectories/tau-retail/instruction_adherence_failure.json --out-path out/static_tau.json
 
   # Magentic-one:
-  python -m invariants.static_invariant_generator --domain magentic --input-path ../trajectories/magentic-one/trajectories/invent_new_info.json --out-path out/static_magentic.json --endpoint trapi
+  python -m invariants.static_invariant_generator --domain magentic --input-path ../trajectories/magentic-one/trajectories/invent_new_info.json --out-path out/static_magentic.json
 
   # With NL check invariants enabled:
-  python -m invariants.static_invariant_generator --domain tau --input-path ../trajectories/tau-retail/instruction_adherence_failure.json --out-path out/static_tau_nl.json --endpoint trapi --include-nl-check
+  python -m invariants.static_invariant_generator --domain tau --input-path ../trajectories/tau-retail/instruction_adherence_failure.json --out-path out/static_tau_nl.json --include-nl-check
 
   # Custom policy document:
   python -m invariants.static_invariant_generator --domain tau --input-path ../trajectories/tau-retail/instruction_adherence_failure.json --out-path out/static.json --policy-path /path/to/policy.txt
 
-  # Using Azure endpoint instead of TRAPI:
-  python -m invariants.static_invariant_generator --domain magentic --input-path ../trajectories/magentic-one/trajectories/invent_new_info.json --out-path out/static.json --endpoint azure
+  # Using TRAPI endpoint (Microsoft Research internal):
+  python -m invariants.static_invariant_generator --domain magentic --input-path ../trajectories/magentic-one/trajectories/invent_new_info.json --out-path out/static.json --endpoint trapi
 
 Also importable for the larger pipeline:
   from invariants.static_invariant_generator import StaticInvariantGenerator
@@ -736,7 +736,7 @@ class StaticInvariantGenerator:
         out_path: str,
         model_name: Optional[str] = None,
         include_nl_check: bool = True,
-        endpoint: str = "trapi",
+        endpoint: str = "azure",
     ) -> None:
         self.traj_for_enums = traj_for_enums
         self.tools_list = [t.strip() for t in (tools_list or []) if (t or "").strip()]
@@ -831,11 +831,19 @@ class StaticInvariantGenerator:
         start_ts = datetime.datetime.now()
         start = time.perf_counter()
 
-        resp = self.client.chat.completions.create(
-            model=self.model_name,
-            messages=[{"role": "user", "content": prompt}],
-            response_format={"type": "json_object"},
-        )
+        try:
+            resp = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
+            )
+        except Exception as e:
+            if "context_length_exceeded" in str(e):
+                raise RuntimeError(
+                    f"Trajectory too large for the model's context window. "
+                    f"Use a model with a larger context limit.\n{e}"
+                )
+            raise
 
         end = time.perf_counter()
         end_ts = datetime.datetime.now()
@@ -888,9 +896,9 @@ if __name__ == "__main__":
                         help="Output path for static invariants JSON")
     parser.add_argument("--policy-path", type=str, default=None,
                         help="Path to policy document (default: from domain registry)")
-    parser.add_argument("--endpoint", type=str, default="trapi",
+    parser.add_argument("--endpoint", type=str, default=g.DEFAULT_ENDPOINT,
                         choices=["azure", "trapi"],
-                        help="LLM endpoint to use (default: trapi)")
+                        help="LLM endpoint to use (default: azure)")
     grp = parser.add_mutually_exclusive_group()
     parser.set_defaults(include_nl_check=False)
     grp.add_argument("--include-nl-check", dest="include_nl_check", action="store_true")

--- a/src/ir/trajectory_ir.py
+++ b/src/ir/trajectory_ir.py
@@ -534,6 +534,7 @@ Expected output:
 def llm_ir(
     trajectories: List[Dict[str, Any]],
     *,
+    endpoint: str = "azure",
     max_retries: int = 5,
     verbose: bool = True,
 ) -> List[Dict[str, Any]]:
@@ -543,16 +544,19 @@ def llm_ir(
     Sends each raw trajectory to an LLM with the IR schema + rules, parses
     the response, validates with validate_ir(), and retries (feeding the
     validation error back) until success or max_retries is exhausted.
-
-    The LLM client is created lazily using the same TRAPI pattern as the
-    rest of the codebase.
     """
-    # Lazy-import to avoid circular deps and heavy init at import time
-    from llm_clients.trapi import LLMAgent as LLMAgentTrapi
     import pipeline.globals as g
 
-    client = LLMAgentTrapi.trapi_mk_client()
-    model = g.TRAPI_DEPLOYMENT_NAME
+    if endpoint == "azure":
+        from llm_clients.azure import LLMAgent as LLMAgentAzure
+        client = LLMAgentAzure.azure_mk_client()
+        model = g.DEPLOYMENT
+    elif endpoint == "trapi":
+        from llm_clients.trapi import LLMAgent as LLMAgentTrapi
+        client = LLMAgentTrapi.trapi_mk_client()
+        model = g.TRAPI_DEPLOYMENT_NAME
+    else:
+        raise ValueError(f"Unknown endpoint: {endpoint!r}. Expected 'azure' or 'trapi'.")
 
     results: List[Dict[str, Any]] = []
 
@@ -589,6 +593,12 @@ def llm_ir(
                 )
             except Exception as api_err:
                 last_error = f"API error: {api_err}"
+                if "context_length_exceeded" in str(api_err):
+                    raise RuntimeError(
+                        f"Trajectory {t_idx} exceeds the model's context window. "
+                        f"Use a model with a larger context limit or split the trajectory file.\n"
+                        f"{api_err}"
+                    )
                 if verbose:
                     print(f"[LLM-IR]   API error: {api_err}", flush=True)
                 continue

--- a/src/judge/judge.py
+++ b/src/judge/judge.py
@@ -1824,7 +1824,7 @@ def main():
                         help='Path to trajectory log file or directory')
     parser.add_argument('--ground_truth_file', default='ground_truth_tau_retail.json',
                         help='Path to ground truth JSON file for accuracy evaluation')
-    parser.add_argument('--endpoint', default='azure', choices=['azure', 'trapi'],
+    parser.add_argument('--endpoint', default=g.DEFAULT_ENDPOINT, choices=['azure', 'trapi'],
                         help='LLM API endpoint to use')
     parser.add_argument('--with-context', action='store_true',
                         help='Include invariant violation context in prompts')

--- a/src/llm_clients/trapi.py
+++ b/src/llm_clients/trapi.py
@@ -1,4 +1,4 @@
-import os 
+import os
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -17,8 +17,9 @@ class LLMAgent:
             api_version,
             model_name,
             model_version,
-            deployment_name):
-        self.scope = os.getenv("SCOPE", "")
+            deployment_name,
+            scope=None):
+        self.scope = scope or os.getenv("SCOPE", "")
         self.credential = get_bearer_token_provider(
         ChainedTokenCredential(AzureCliCredential(), ManagedIdentityCredential()),
         self.scope,
@@ -39,10 +40,10 @@ class LLMAgent:
             messages=messages
         )
         return response
-    
+
     @staticmethod
-    def trapi_mk_client() -> AzureOpenAI:
-        scope = os.getenv("SCOPE", "")
+    def trapi_mk_client(scope=None) -> AzureOpenAI:
+        scope = scope or os.getenv("SCOPE", "")
         credential = get_bearer_token_provider(
             ChainedTokenCredential(AzureCliCredential(), ManagedIdentityCredential()),
             scope,

--- a/src/pipeline/globals.py
+++ b/src/pipeline/globals.py
@@ -58,6 +58,10 @@ MAGENTIC_TASK_IDS = [
     "f88066d274e265edd6cd9d61cd80a41accb3a14baf2297652fdd05cdf716d455",
 ]
 
+DEFAULT_ENDPOINT = os.environ.get("AGENT_VERIFY_ENDPOINT_TYPE", "azure")  # "azure" or "trapi"
+if DEFAULT_ENDPOINT not in ("azure", "trapi"):
+    raise ValueError(f"AGENT_VERIFY_ENDPOINT_TYPE must be 'azure' or 'trapi', got: {DEFAULT_ENDPOINT!r}")
+
 TRAPI_INSTANCE = os.environ.get("AGENT_VERIFY_TRAPI_INSTANCE", "")  # See https://aka.ms/trapi/models for the instance name
 TRAPI_ENDPOINT_PREFIX = os.environ.get("AGENT_VERIFY_TRAPI_ENDPOINT_PREFIX", "https://trapi.research.microsoft.com/")
 TRAPI_API_VERSION = os.environ.get("AGENT_VERIFY_TRAPI_API_VERSION", "2025-03-01-preview")  # See: https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation#latest-ga-api-release

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,0 +1,45 @@
+# Troubleshooting
+
+## Azure Authentication
+
+### `DefaultAzureCredential` fails on first run (IMDS timeout)
+
+**Symptom:** The first pipeline run fails with a long error listing all attempted credentials:
+```
+DefaultAzureCredential failed to retrieve a token from the included credentials.
+Attempted credentials:
+  ManagedIdentityCredential: ManagedIdentityCredential authentication unavailable, no response from the IMDS endpoint.
+  AzureCliCredential: Failed to invoke the Azure CLI
+  ...
+```
+
+**Cause:** `DefaultAzureCredential` tries `ManagedIdentityCredential` early in its chain. On a local dev machine, this attempts to contact the IMDS endpoint which doesn't exist locally, so it blocks until the network timeout (~5-10s). This can exhaust the overall credential chain timeout or cause cascading failures before `AzureCliCredential` gets a chance to run.
+
+This is a known issue across all Azure SDKs: [azure-sdk-for-python #35452](https://github.com/Azure/azure-sdk-for-python/issues/35452)
+
+**Workarounds:**
+
+1. **Retry** — subsequent runs typically succeed because the token gets cached.
+
+2. **Warm the cache first** — run this before the pipeline:
+   ```bash
+   .venv/Scripts/python -c "from azure.identity import AzureCliCredential; AzureCliCredential().get_token('https://cognitiveservices.azure.com/.default'); print('Token cached')"
+   ```
+
+3. **Exclude ManagedIdentityCredential** — in `src/llm_clients/azure.py`, change:
+   ```python
+   DefaultAzureCredential(managed_identity_client_id=g.CLIENT_ID)
+   ```
+   to:
+   ```python
+   DefaultAzureCredential(exclude_managed_identity_credential=True)
+   ```
+   This skips the IMDS probe entirely. Only use this for local dev — do not commit if running in Azure (where managed identity is needed).
+
+### Prerequisite: `az login`
+
+The pipeline uses Azure AD token-based auth. You must be logged in:
+```bash
+az login
+az account show  # verify
+```


### PR DESCRIPTION
 1. Provides support for both Azure and TRAPI wherever LLM calls are being made (some places were using only TRAPI clients)
  2. Made Azure the default everywhere and added an env variable (AGENT_VERIFY_ENDPOINT_TYPE) for users to override this
  3. Catching LLM call exceptions at all places and added a custom message for context window size violations