### PR TITLE
Update the dev_cred troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ See [requirements.txt](requirements.txt) for the full list of dependencies.
 
 ### `DefaultAzureCredential` timeout on local machines
 
-The Azure SDK's `DefaultAzureCredential` tries `ManagedIdentityCredential` before `AzureCliCredential`. On a local dev machine this probes the IMDS endpoint which doesn't exist locally, causing a ~5-10s timeout before falling back. This is a [known Azure SDK issue](https://github.com/Azure/azure-sdk-for-python/issues/35452).
+The Azure SDK's `DefaultAzureCredential` tries `ManagedIdentityCredential` before `AzureCliCredential`. On a local dev machine this probes the IMDS endpoint which doesn't exist locally, causing a ~5-10s timeout before falling back. This is expected behavior — the probe is how `DefaultAzureCredential` detects the hosting environment.
 
 **Fix:** Set the `AZURE_TOKEN_CREDENTIALS` environment variable to `dev` to exclude deployed-service credentials (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`) from the chain, so `DefaultAzureCredential` skips straight to developer-tool credentials like `AzureCliCredential`:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ python -m venv .venv
 pip install -r requirements.txt
 cp .env.example .env            # Fill in your Azure or TRAPI endpoint details
 
+# Local dev: skip ManagedIdentity IMDS probe
+export AZURE_TOKEN_CREDENTIALS=dev  # or add to your .env file
+
 # Run the full pipeline end-to-end
 python run.py trajectory.json
 

--- a/README.md
+++ b/README.md
@@ -192,10 +192,19 @@ See [requirements.txt](requirements.txt) for the full list of dependencies.
 
 The Azure SDK's `DefaultAzureCredential` tries `ManagedIdentityCredential` before `AzureCliCredential`. On a local dev machine this probes the IMDS endpoint which doesn't exist locally, causing a ~5-10s timeout before falling back. This is a [known Azure SDK issue](https://github.com/Azure/azure-sdk-for-python/issues/35452).
 
-**Workaround:** retry (the token gets cached), or warm the cache first:
+**Fix:** Set the `AZURE_TOKEN_CREDENTIALS` environment variable to `dev` to exclude deployed-service credentials (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`) from the chain, so `DefaultAzureCredential` skips straight to developer-tool credentials like `AzureCliCredential`:
+
 ```bash
-.venv/Scripts/python -c "from azure.identity import AzureCliCredential; AzureCliCredential().get_token('https://cognitiveservices.azure.com/.default'); print('Token cached')"
+# PowerShell
+$env:AZURE_TOKEN_CREDENTIALS = "dev"
+
+# Bash / Linux / macOS
+export AZURE_TOKEN_CREDENTIALS=dev
 ```
+
+Or add `AZURE_TOKEN_CREDENTIALS=dev` to your `.env` file.
+
+> Requires `azure-identity >= 1.23.0`. See [Exclude a credential type category](https://learn.microsoft.com/azure/developer/python/sdk/authentication/credential-chains?tabs=dac#exclude-a-credential-type-category) for details.
 
 ---
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -17,24 +17,19 @@ Attempted credentials:
 
 This is a known issue across all Azure SDKs: [azure-sdk-for-python #35452](https://github.com/Azure/azure-sdk-for-python/issues/35452)
 
-**Workarounds:**
+**Fix:** Set the `AZURE_TOKEN_CREDENTIALS` environment variable to `dev` to exclude deployed-service credentials (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`) from the chain, so `DefaultAzureCredential` skips straight to developer-tool credentials like `AzureCliCredential`:
 
-1. **Retry** — subsequent runs typically succeed because the token gets cached.
+```bash
+# PowerShell
+$env:AZURE_TOKEN_CREDENTIALS = "dev"
 
-2. **Warm the cache first** — run this before the pipeline:
-   ```bash
-   .venv/Scripts/python -c "from azure.identity import AzureCliCredential; AzureCliCredential().get_token('https://cognitiveservices.azure.com/.default'); print('Token cached')"
-   ```
+# Bash / Linux / macOS
+export AZURE_TOKEN_CREDENTIALS=dev
+```
 
-3. **Exclude ManagedIdentityCredential** — in `src/llm_clients/azure.py`, change:
-   ```python
-   DefaultAzureCredential(managed_identity_client_id=g.CLIENT_ID)
-   ```
-   to:
-   ```python
-   DefaultAzureCredential(exclude_managed_identity_credential=True)
-   ```
-   This skips the IMDS probe entirely. Only use this for local dev — do not commit if running in Azure (where managed identity is needed).
+Or add `AZURE_TOKEN_CREDENTIALS=dev` to your `.env` file.
+
+> Requires `azure-identity >= 1.23.0`. See [Exclude a credential type category](https://learn.microsoft.com/azure/developer/python/sdk/authentication/credential-chains?tabs=dac#exclude-a-credential-type-category) for details.
 
 ### Prerequisite: `az login`
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -15,7 +15,7 @@ Attempted credentials:
 
 **Cause:** `DefaultAzureCredential` tries `ManagedIdentityCredential` early in its chain. On a local dev machine, this attempts to contact the IMDS endpoint which doesn't exist locally, so it blocks until the network timeout (~5-10s). This can exhaust the overall credential chain timeout or cause cascading failures before `AzureCliCredential` gets a chance to run.
 
-This is a known issue across all Azure SDKs: [azure-sdk-for-python #35452](https://github.com/Azure/azure-sdk-for-python/issues/35452)
+This is expected behavior — `DefaultAzureCredential` probes the IMDS endpoint to detect the hosting environment, and the timeout is unavoidable on local machines unless the credential chain is configured to skip it.
 
 **Fix:** Set the `AZURE_TOKEN_CREDENTIALS` environment variable to `dev` to exclude deployed-service credentials (e.g. `ManagedIdentityCredential`, `WorkloadIdentityCredential`) from the chain, so `DefaultAzureCredential` skips straight to developer-tool credentials like `AzureCliCredential`:
 


### PR DESCRIPTION
I'm a maintainer of the https://github.com/Azure/azure-sdk-for-python repo and would like to contribute to the troubleshooting section about the DefaultAzureCredential IMDS timeout that many developers encounter on first run.

The fix (AZURE_TOKEN_CREDENTIALS=dev) is an officially supported feature we shipped specifically for this scenario.

