### PR TITLE
Add Copilot CLI as third LLM endpoint + fix parsing/sandbox/trigger/judge bugs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,21 @@
 
 
 # ----------------------------------------------------------
-# Default endpoint type: "azure" or "trapi" (override per-command with --endpoint)
-# Both endpoints use Azure AD token auth (run `az login` first)
+# Default endpoint type: "copilot", "azure", or "trapi" (override per-command with --endpoint)
+#   copilot — uses GitHub Copilot CLI (no Azure creds needed, just `gh auth login`)
+#   azure   — Azure OpenAI (run `az login` first)
+#   trapi   — Microsoft Research internal (run `az login` first)
 # ----------------------------------------------------------
-AGENT_VERIFY_ENDPOINT_TYPE=azure
+AGENT_VERIFY_ENDPOINT_TYPE=copilot
 
 # ----------------------------------------------------------
-# Azure OpenAI endpoint (default)
+# Copilot CLI endpoint (default) — no extra config needed
+# Just ensure `copilot` is on PATH and authenticated via `gh auth login`
+# ----------------------------------------------------------
+# AGENT_VERIFY_COPILOT_TIMEOUT=600    # optional: timeout in seconds per LLM call
+
+# ----------------------------------------------------------
+# Azure OpenAI endpoint (use --endpoint azure)
 # ----------------------------------------------------------
 AGENT_VERIFY_ENDPOINT=                # e.g. https://my-resource.openai.azure.com/
 AGENT_VERIFY_DEPLOYMENT=gpt-5         # model deployment name

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,14 @@ AGENT_VERIFY_ENDPOINT_TYPE=copilot
 # Copilot CLI endpoint (default) — no extra config needed
 # Just ensure `copilot` is on PATH and authenticated via `gh auth login`
 # ----------------------------------------------------------
-# AGENT_VERIFY_COPILOT_TIMEOUT=600    # optional: timeout in seconds per LLM call
+# AGENT_VERIFY_COPILOT_TIMEOUT=600          # optional: timeout in seconds per LLM call
+# Supported models (run `copilot --help` for the current list):
+#   claude-opus-4.6   (default)
+#   claude-sonnet-4.5
+#   gpt-5
+#   gpt-5-mini
+#   gpt-5-codex
+AGENT_VERIFY_COPILOT_MODEL=claude-opus-4.6
 
 # ----------------------------------------------------------
 # Azure OpenAI endpoint (use --endpoint azure)

--- a/run.py
+++ b/run.py
@@ -96,7 +96,10 @@ def banner(msg: str):
 def validate_endpoint_config(endpoint: str):
     """Validate that required environment variables are set for the chosen endpoint."""
     missing = []
-    if endpoint == "trapi":
+    if endpoint == "copilot":
+        # Copilot CLI needs no env vars — just the binary on PATH
+        pass
+    elif endpoint == "trapi":
         if not g.TRAPI_INSTANCE:
             missing.append("AGENT_VERIFY_TRAPI_INSTANCE")
         if not g.TRAPI_DEPLOYMENT_NAME:
@@ -107,7 +110,7 @@ def validate_endpoint_config(endpoint: str):
         if not g.ENDPOINT:
             missing.append("AGENT_VERIFY_ENDPOINT")
     else:
-        print(f"\nError: Unknown endpoint '{endpoint}'. Must be 'azure' or 'trapi'.")
+        print(f"\nError: Unknown endpoint '{endpoint}'. Must be 'copilot', 'azure', or 'trapi'.")
         sys.exit(1)
 
     if missing:
@@ -233,12 +236,14 @@ def run_static(input_path: str, run_dir: str, domain: str, endpoint: str,
 # ---------- Stage: Dynamic Invariants ----------
 
 def run_dynamic(input_path: str, run_dir: str, domain: str, endpoint: str,
-                static_invariants_path: str, state: dict) -> str:
+                static_invariants_path: str, state: dict,
+                dynamic_mode: str = "stepbystep") -> str:
     """Generate dynamic invariants. Returns path to output directory."""
-    from invariants.dynamic_invariant_generator import DynamicInvariantGenerator
+    from invariants.dynamic_invariant_generator import DynamicInvariantGenerator, OneShotDynamicInvariantGenerator
     from invariants.domain_registry import get_domain_config
 
-    banner("Stage 3/6: Dynamic Invariant Generation")
+    mode_label = "one-shot" if dynamic_mode == "oneshot" else "step-by-step"
+    banner(f"Stage 3/6: Dynamic Invariant Generation ({mode_label})")
 
     out_dir = os.path.join(run_dir, "dynamic_invariants")
     ensure_dir(out_dir)
@@ -254,7 +259,8 @@ def run_dynamic(input_path: str, run_dir: str, domain: str, endpoint: str,
         tools_list = cfg.tools_list
         tools_structure = cfg.tools_structure
 
-    gen = DynamicInvariantGenerator(
+    GeneratorClass = OneShotDynamicInvariantGenerator if dynamic_mode == "oneshot" else DynamicInvariantGenerator
+    gen = GeneratorClass(
         out_dir=out_dir,
         static_invariants_path=static_invariants_path,
         domain=domain,
@@ -400,14 +406,17 @@ def run_judge(input_path: str, run_dir: str, domain: str, endpoint: str,
     print(f"  [DEBUG][run_judge] api_version:           {api_version}")
     print(f"  [DEBUG][run_judge] model_name:            {model_name}")
 
-    # Run a single iteration
+    # Run a single iteration.
+    # Use the IR file (already normalized) so the judge doesn't re-normalize
+    # and lose trajectories.
+    ir_file = os.path.join(run_dir, "trajectory_ir.json")
     judge_module.run_single_iteration(
         run_number=1,
         base_output_dir=judge_out_dir,
         ground_truth_failures=gt_failures,
         api_version=api_version,
         model_name=model_name,
-        log_file=input_path,
+        log_file=ir_file if os.path.exists(ir_file) else input_path,
     )
 
     print(f"  Output: {judge_out_dir}")
@@ -503,14 +512,16 @@ Examples:
     parser.add_argument("--domain", default=None,
                         choices=["tau", "flash", "magentic"],
                         help="Domain (auto-detected if not specified)")
-    parser.add_argument("--endpoint", default=g.DEFAULT_ENDPOINT, choices=["azure", "trapi"],
-                        help="LLM endpoint (default: azure). TRAPI is Microsoft Research internal.")
+    parser.add_argument("--endpoint", default=g.DEFAULT_ENDPOINT, choices=["copilot", "azure", "trapi"],
+                        help="LLM endpoint (default: copilot). Options: copilot (GitHub CLI), azure, trapi.")
     parser.add_argument("--stage", default=None, choices=STAGES,
                         help="Run ONLY this stage")
     parser.add_argument("--from-stage", default=None, choices=STAGES,
                         help="Resume from this stage (skips earlier stages)")
     parser.add_argument("--skip-dynamic", action="store_true",
                         help="Skip dynamic invariant generation (faster)")
+    parser.add_argument("--dynamic-mode", default="stepbystep", choices=["stepbystep", "oneshot"],
+                        help="Dynamic invariant mode: stepbystep (per-step, slower) or oneshot (single LLM call per trajectory, faster)")
     parser.add_argument("--skip-judge", action="store_true",
                         help="Skip judge and report stages")
     parser.add_argument("--ground-truth", default=None,
@@ -653,7 +664,8 @@ def run_pipeline(input_path: str, args):
 
         # --- Dynamic Invariants ---
         if "dynamic" in stages_to_run:
-            dynamic_inv_dir = run_dynamic(input_path, run_dir, domain, args.endpoint, static_inv_path, state)
+            dynamic_inv_dir = run_dynamic(input_path, run_dir, domain, args.endpoint, static_inv_path, state,
+                                          dynamic_mode=args.dynamic_mode)
             state["completed_stages"] = list(set(state.get("completed_stages", [])) | {"dynamic"})
             save_state(run_dir, state)
 

--- a/src/invariants/checker.py
+++ b/src/invariants/checker.py
@@ -195,7 +195,11 @@ class AllVerifier:
                     dbg(f"      event_trigger={jdump(trig, maxlen=800)}")
                 dbg(f"      check_type_field={inv.get('check_type')!r} check_field={inv.get('check')!r} inferred={self._infer_check_type(inv)!r}")
 
-        if self.client == "azure":
+        if self.client == "copilot":
+            from llm_clients.copilot_cli import copilot_mk_client
+            self.llm_client = copilot_mk_client()
+            self.model_name = "copilot-cli"
+        elif self.client == "azure":
             self.llm_client = LLMAgentAzure.azure_mk_client()
             self.model_name = g.DEPLOYMENT
         else:
@@ -271,6 +275,10 @@ class AllVerifier:
                 dbg(f"Loaded {dynamic_count} dynamic invariants from per_step_outputs")
             return out
 
+        # Also check one-shot format: dynamic invariants stored directly
+        if "dynamic_invariants" in data:
+            add_payload(data.get("dynamic_invariants"))
+
         if "invariants" in data:
             add_payload(data.get("invariants"))
             return out
@@ -333,27 +341,44 @@ class AllVerifier:
         return f"step_pos={step_pos} step.index={idx!r} substeps={len(subs) if isinstance(subs, list) else 'NONLIST'}"
 
     def _step_matches_trigger(self, trig_step: Any, step_pos: int, step_obj: Dict[str, Any]) -> bool:
-        """ # TODO
+        """
         We DO NOT rewrite trigger.step_index. But to avoid obvious off-by-one pains,
         we accept a match if:
           - trigger_step == step_pos
           - OR trigger_step == step_pos + 1
           - OR trigger_step == step_obj.get("index") (if present and int-ish)
+          - OR trigger_step is a range like "20-21" and step_pos/index falls in it
         """
         if trig_step in (None, "", "*"):
             return True
 
+        step_index_field = safe_int(step_obj.get("index"))
+
+        # Try simple integer match first
         t = safe_int(trig_step)
-        if t is None:
+        if t is not None:
+            if t == step_pos:
+                return True
+            if t == step_pos + 1:
+                return True
+            if step_index_field is not None and t == step_index_field:
+                return True
             return False
 
-        step_index_field = safe_int(step_obj.get("index"))
-        if t == step_pos:
-            return True
-        if t == step_pos + 1:
-            return True
-        if step_index_field is not None and t == step_index_field:
-            return True
+        # Handle range triggers like "20-21", "15-20"
+        trig_str = str(trig_step).strip()
+        if "-" in trig_str:
+            parts = trig_str.split("-", 1)
+            lo = safe_int(parts[0].strip())
+            hi = safe_int(parts[1].strip())
+            if lo is not None and hi is not None:
+                # Check both step_pos (0-based) and step.index (1-based)
+                if lo <= step_pos <= hi:
+                    return True
+                if lo <= step_pos + 1 <= hi:
+                    return True
+                if step_index_field is not None and lo <= step_index_field <= hi:
+                    return True
 
         return False
 
@@ -569,27 +594,19 @@ class AllVerifier:
             m.POLICY_TEXT = self.policy_text
             sys.modules["policy_text"] = m
 
-            # Strip redundant import lines for modules already provided in the
-            # sandbox — the restricted builtins intentionally omit __import__ so
-            # bare `import x` would crash with "ImportError: __import__ not found".
-            _provided_modules = {"json", "re", "math", "collections"}
-            sanitized_lines = []
-            for line in code.splitlines():
-                stripped = line.strip()
-                if stripped.startswith("import "):
-                    mod = stripped.split()[1].split(".")[0].rstrip(",")
-                    if mod in _provided_modules:
-                        continue
-                elif stripped.startswith("from ") and " import " in stripped:
-                    mod = stripped.split()[1].split(".")[0]
-                    if mod in _provided_modules:
-                        continue
-                sanitized_lines.append(line)
-            code = "\n".join(sanitized_lines)
+            # Allow __import__ so generated checks can do 'import json', 'import re', etc.
+            # We restrict to a safe allowlist of modules.
+            _allowed_modules = {"json", "re", "math", "datetime", "collections", "itertools", "functools", "string"}
+            _real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+            def _safe_import(name, *args, **kwargs):
+                if name.split(".")[0] not in _allowed_modules:
+                    raise ImportError(f"Import of '{name}' is not allowed in invariant checks")
+                return _real_import(name, *args, **kwargs)
 
             import collections as _collections
             import math as _math
             _safe_builtins = {
+                "__import__": _safe_import,
                 "str": str, "int": int, "float": float, "bool": bool,
                 "dict": dict, "list": list, "tuple": tuple, "set": set,
                 "len": len, "range": range, "enumerate": enumerate,

--- a/src/invariants/dynamic_invariant_generator.py
+++ b/src/invariants/dynamic_invariant_generator.py
@@ -1865,7 +1865,11 @@ class DynamicInvariantGenerator:
         self.tools_structure = tools_structure
         self.include_nl_check = include_nl_check
 
-        if endpoint == "azure":
+        if endpoint == "copilot":
+            from llm_clients.copilot_cli import copilot_mk_client
+            self.client = copilot_mk_client()
+            self.model_name = model_name or "copilot-cli"
+        elif endpoint == "azure":
             self.client = LLMAgentAzure.azure_mk_client()
             self.model_name = model_name or g.DEPLOYMENT
         else:
@@ -1991,8 +1995,11 @@ class DynamicInvariantGenerator:
                     obj = json.loads(raw_text)
                     if isinstance(obj, dict):
                         parsed_obj = obj
+                    elif isinstance(obj, list):
+                        # Model returned a bare array — wrap it
+                        parsed_obj = {"invariant": obj}
                     else:
-                        parse_error = "Model returned non-object JSON"
+                        parse_error = f"Model returned {type(obj).__name__}, expected dict or list"
                 except Exception as e:
                     parse_error = str(e)
 
@@ -2032,7 +2039,9 @@ class DynamicInvariantGenerator:
                 }
                 # Accumulate invariant objects for future steps ("previous_assertions")
                 if isinstance(parsed_obj, dict):
-                    inv_list = parsed_obj.get("invariant") or []
+                    inv_list = (parsed_obj.get("invariant")
+                                or parsed_obj.get("invariants")
+                                or parsed_obj.get("dynamic_invariants") or [])
                     if isinstance(inv_list, list):
                         dynamic_invariants.extend([x for x in inv_list if isinstance(x, dict)])
                 per_step_outputs.append(record)
@@ -2144,7 +2153,11 @@ class OneShotDynamicInvariantGenerator:
         self.tools_structure = tools_structure
         self.include_nl_check = include_nl_check
 
-        if endpoint == "azure":
+        if endpoint == "copilot":
+            from llm_clients.copilot_cli import copilot_mk_client
+            self.client = copilot_mk_client()
+            self.model_name = model_name or "copilot-cli"
+        elif endpoint == "azure":
             self.client = LLMAgentAzure.azure_mk_client()
             self.model_name = model_name or g.DEPLOYMENT
         else:
@@ -2240,9 +2253,13 @@ class OneShotDynamicInvariantGenerator:
             parse_error: Optional[str] = None
             try:
                 obj = json.loads(raw_text)
-                parsed_obj = obj if isinstance(obj, dict) else None
-                if parsed_obj is None:
-                    parse_error = "Model returned non-object JSON"
+                if isinstance(obj, dict):
+                    parsed_obj = obj
+                elif isinstance(obj, list):
+                    # Model returned a bare array — wrap it
+                    parsed_obj = {"invariant": obj}
+                else:
+                    parse_error = f"Model returned {type(obj).__name__}, expected dict or list"
             except Exception as e:
                 parse_error = str(e)
 
@@ -2263,7 +2280,9 @@ class OneShotDynamicInvariantGenerator:
 
             dynamic_invariants: List[dict] = []
             if isinstance(parsed_obj, dict):
-                inv_list = parsed_obj.get("invariant") or []
+                inv_list = (parsed_obj.get("invariant")
+                            or parsed_obj.get("invariants")
+                            or parsed_obj.get("dynamic_invariants") or [])
                 if isinstance(inv_list, list):
                     dynamic_invariants = [x for x in inv_list if isinstance(x, dict)]
 

--- a/src/invariants/static_invariant_generator.py
+++ b/src/invariants/static_invariant_generator.py
@@ -765,7 +765,12 @@ class StaticInvariantGenerator:
             
         ensure_dir(os.path.dirname(self.out_path))
 
-        if endpoint == "azure":
+        if endpoint == "copilot":
+            from llm_clients.copilot_cli import copilot_mk_client
+            self.client = copilot_mk_client()
+            self.model_name = model_name or "copilot-cli"
+            self._endpoint_url = "copilot-cli"
+        elif endpoint == "azure":
             self.client = LLMAgentAzure.azure_mk_client()
             self.model_name = model_name or g.DEPLOYMENT
             self._endpoint_url = g.ENDPOINT
@@ -854,8 +859,12 @@ class StaticInvariantGenerator:
         raw = (resp.choices[0].message.content or "").strip()
         try:
             obj = json.loads(raw)
+            # Copilot CLI may return a bare array instead of {"invariants": [...]}.
+            # Wrap it so downstream code always sees a dict.
+            if isinstance(obj, list):
+                obj = {"invariants": obj}
             if not isinstance(obj, dict):
-                raise ValueError("model returned non-object JSON")
+                raise ValueError(f"model returned {type(obj).__name__}, expected dict or list")
         except Exception as e:
             raise RuntimeError(
                 f"Static invariants JSON parse failed: {e}\n")

--- a/src/ir/trajectory_ir.py
+++ b/src/ir/trajectory_ir.py
@@ -665,7 +665,11 @@ def llm_ir(
     """
     import pipeline.globals as g
 
-    if endpoint == "azure":
+    if endpoint == "copilot":
+        from llm_clients.copilot_cli import copilot_mk_client
+        client = copilot_mk_client()
+        model = "copilot-cli"
+    elif endpoint == "azure":
         from llm_clients.azure import LLMAgent as LLMAgentAzure
         client = LLMAgentAzure.azure_mk_client()
         model = g.DEPLOYMENT
@@ -674,7 +678,7 @@ def llm_ir(
         client = LLMAgentTrapi.trapi_mk_client()
         model = g.TRAPI_DEPLOYMENT_NAME
     else:
-        raise ValueError(f"Unknown endpoint: {endpoint!r}. Expected 'azure' or 'trapi'.")
+        raise ValueError(f"Unknown endpoint: {endpoint!r}. Expected 'copilot', 'azure', or 'trapi'.")
 
     # Max chars for the raw trajectory JSON sent to the LLM.
     # ~200K tokens ≈ 800K chars, leaving room for system prompt + response.

--- a/src/judge/judge.py
+++ b/src/judge/judge.py
@@ -44,7 +44,7 @@ RESULTS_DIR = "output_results"
 
 # Global Configs (will be updated by main)
 RUN_WITH_CONTEXT = False
-ENDPOINT_USED = None # will be set in main
+ENDPOINT_USED = None  # will be set in main — "copilot", "azure", or "trapi"
 USE_GROUND_TRUTH = True
 PROMPT_MODE = "combined"     # "baseline", "checklist", "examples", "combined"
 EXECUTION_MODE = "violations-after" # "violations-after", "stepbystep", "violations-before"
@@ -818,7 +818,13 @@ def _normalize_by_domain(domain: str, raw):
 # --- Judge Class (Merged Logic) ---
 
 def get_llm_judge_class():
-    base_class = LLMAgentAzure if ENDPOINT_USED == "azure" else LLMAgentTrapi
+    if ENDPOINT_USED == "copilot":
+        from llm_clients.copilot_cli import LLMAgent as LLMAgentCopilot
+        base_class = LLMAgentCopilot
+    elif ENDPOINT_USED == "azure":
+        base_class = LLMAgentAzure
+    else:
+        base_class = LLMAgentTrapi
     
     class LLMJudge(base_class):
         def _parse_json_response(self, response, context_name="LLM", max_retries=2):
@@ -1069,10 +1075,14 @@ def judge_trajectories(log_file, num_runs=1, ground_truth_task_ids=None):
     # Assuming params from global g or env
     # Note: Azure globals only has API_VERSION, MODEL_NAME, DEPLOYMENT (no MODEL_VERSION)
     # TRAPI has TRAPI_API_VERSION, TRAPI_MODEL_NAME, TRAPI_MODEL_VERSION, TRAPI_DEPLOYMENT_NAME
-    api_version = g.API_VERSION if ENDPOINT_USED == "azure" else g.TRAPI_API_VERSION
-    model_name = g.MODEL_NAME if ENDPOINT_USED == "azure" else g.TRAPI_MODEL_NAME
-    model_version = g.MODEL_NAME if ENDPOINT_USED == "azure" else g.TRAPI_MODEL_VERSION
-    deployment_name = g.DEPLOYMENT if ENDPOINT_USED == "azure" else g.TRAPI_DEPLOYMENT_NAME
+    if ENDPOINT_USED == "copilot":
+        api_version, model_name, model_version, deployment_name = "", "copilot-cli", "", "copilot-cli"
+    elif ENDPOINT_USED == "azure":
+        api_version, model_name = g.API_VERSION, g.MODEL_NAME
+        model_version, deployment_name = g.MODEL_NAME, g.DEPLOYMENT
+    else:
+        api_version, model_name = g.TRAPI_API_VERSION, g.TRAPI_MODEL_NAME
+        model_version, deployment_name = g.TRAPI_MODEL_VERSION, g.TRAPI_DEPLOYMENT_NAME
 
     judge = LLMJudge(api_version=api_version, model_name=model_name, model_version=model_version, deployment_name=deployment_name)
     
@@ -1806,8 +1816,8 @@ def main():
                         help='Path to trajectory log file or directory')
     parser.add_argument('--ground_truth_file', default='ground_truth_tau_retail.json',
                         help='Path to ground truth JSON file for accuracy evaluation')
-    parser.add_argument('--endpoint', default=g.DEFAULT_ENDPOINT, choices=['azure', 'trapi'],
-                        help='LLM API endpoint to use')
+    parser.add_argument('--endpoint', default=g.DEFAULT_ENDPOINT, choices=['copilot', 'azure', 'trapi'],
+                        help='LLM API endpoint to use (default: copilot)')
     parser.add_argument('--with-context', action='store_true',
                         help='Include invariant violation context in prompts')
     
@@ -1836,7 +1846,10 @@ def main():
     
     # Set endpoint globally
     ENDPOINT_USED = args.endpoint
-    if ENDPOINT_USED == "azure":
+    if ENDPOINT_USED == "copilot":
+        api_version = ""
+        model_name = "copilot-cli"
+    elif ENDPOINT_USED == "azure":
         api_version = g.API_VERSION
         model_name = g.MODEL_NAME
     else:

--- a/src/llm_clients/copilot_cli.py
+++ b/src/llm_clients/copilot_cli.py
@@ -1,0 +1,360 @@
+"""LLM client that delegates to the GitHub Copilot CLI.
+
+Usage:
+    Set AGENT_VERIFY_ENDPOINT_TYPE=copilot in .env (or pass --endpoint copilot).
+    Requires the GitHub Copilot CLI on PATH and authenticated via `gh auth login`.
+
+This module exposes two interfaces so it can be used as a drop-in alongside
+the Azure and TRAPI clients:
+
+    1. CopilotCLIClient  — a thin wrapper with .chat.completions.create(...)
+       that mimics the AzureOpenAI client interface used everywhere in AgentRx.
+    2. LLMAgent           — mirrors llm_clients.azure.LLMAgent so the Judge
+       module can inherit from it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime
+from types import SimpleNamespace
+from typing import List, Dict, Optional
+
+import pipeline.globals as g
+
+try:
+    import reports.metrics as metrics
+except ImportError:
+    metrics = None
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CLI_VERIFIED = False
+_COPILOT_BIN: Optional[str] = None  # resolved absolute path
+
+
+def _refresh_path():
+    """On Windows, refresh os.environ['PATH'] from the registry so that
+    binaries installed after Python started are discoverable."""
+    if sys.platform == "win32":
+        import winreg
+        parts = []
+        for hive, key in [
+            (winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment"),
+            (winreg.HKEY_CURRENT_USER, r"Environment"),
+        ]:
+            try:
+                with winreg.OpenKey(hive, key) as k:
+                    val, _ = winreg.QueryValueEx(k, "Path")
+                    parts.append(val)
+            except OSError:
+                pass
+        if parts:
+            os.environ["PATH"] = ";".join(parts)
+
+
+def _find_copilot_bin() -> str:
+    """Locate the real copilot binary, refreshing PATH if needed.
+    
+    Prefers copilot.exe over .ps1/.cmd wrappers on Windows, because
+    the VS Code bootstrapper (copilot.ps1) may shadow the real binary
+    and prompt interactively.
+    """
+    import shutil
+
+    # Always refresh PATH from registry first — Node/npm/winget installs
+    # done after Python started won't be visible otherwise
+    _refresh_path()
+
+    # On Windows, look for the .exe explicitly to avoid the VS Code
+    # bootstrapper (.ps1) that requires interactive input
+    if sys.platform == "win32":
+        exe_path = shutil.which("copilot.exe")
+        if exe_path:
+            return exe_path
+
+    # Fallback to whatever "copilot" resolves to
+    path = shutil.which("copilot")
+    if path:
+        return path
+
+    raise RuntimeError(
+        "'copilot' CLI not found on PATH.\n"
+        "Install: https://docs.github.com/en/copilot/using-github-copilot/"
+        "using-github-copilot-in-the-command-line\n"
+        "Or:  winget install GitHub.Copilot"
+    )
+
+
+def _verify_cli():
+    """Check once that the copilot binary is reachable."""
+    global _CLI_VERIFIED, _COPILOT_BIN
+    if _CLI_VERIFIED:
+        return
+    _COPILOT_BIN = _find_copilot_bin()
+    try:
+        result = subprocess.run(
+            [_COPILOT_BIN, "--version"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+        )
+        if result.returncode == 0:
+            print(f"[CopilotCLI] Found: {result.stdout.strip()}")
+        else:
+            print("[CopilotCLI] Warning: copilot CLI returned non-zero on --version",
+                  file=sys.stderr)
+    except FileNotFoundError:
+        raise RuntimeError(
+            f"'copilot' binary not executable at: {_COPILOT_BIN}"
+        )
+    _CLI_VERIFIED = True
+
+
+def _flatten_messages(messages: List[Dict[str, str]]) -> str:
+    """Convert OpenAI-style chat messages into a single prompt string."""
+    parts = []
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if not content:
+            continue
+        if role == "system":
+            parts.append(f"<SYSTEM_INSTRUCTIONS>\n{content}\n</SYSTEM_INSTRUCTIONS>")
+        elif role == "user":
+            parts.append(f"<USER_MESSAGE>\n{content}\n</USER_MESSAGE>")
+        elif role == "assistant":
+            parts.append(f"<ASSISTANT_RESPONSE>\n{content}\n</ASSISTANT_RESPONSE>")
+        elif role == "tool":
+            parts.append(f"<TOOL_OUTPUT>\n{content}\n</TOOL_OUTPUT>")
+    return "\n\n".join(parts)
+
+
+COPILOT_TIMEOUT = int(os.getenv("AGENT_VERIFY_COPILOT_TIMEOUT", "600"))
+COPILOT_MODEL = os.getenv("COPILOT_MODEL", "claude-opus-4.6")  # default: Opus 4.6; override via env var
+
+
+# Max characters safe for the -p flag on Windows (WinError 206 above this).
+# Measured via binary search: fails at ~32,687, safe at ~32,281.
+# However, stdin is actually faster (~18s vs ~20s) and has NO size limit
+# (tested up to 200K+ chars), so we always use stdin.
+_MAX_ARG_CHARS = 30_000  # kept for reference; stdin used for everything
+
+
+def _call_cli(prompt: str, timeout: int = None) -> str:
+    """Shell out to the copilot binary and return raw stdout.
+
+    Always pipes the prompt via stdin to avoid Windows command-line length
+    limits (WinError 206 at ~32K chars via -p flag).  Stdin is also ~10%
+    faster and handles 200K+ chars with no issues (~18-20s constant).
+    """
+    timeout = timeout or COPILOT_TIMEOUT
+    _verify_cli()  # ensures _COPILOT_BIN is set
+    binary = _COPILOT_BIN or "copilot"
+
+    cmd = [binary, "-s", "--no-ask-user", "--allow-all",
+           "--output-format", "text"]
+    if COPILOT_MODEL:
+        cmd.extend(["--model", COPILOT_MODEL])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+
+        if result.returncode == 0 and result.stdout and result.stdout.strip():
+            return result.stdout.strip()
+
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()[:300]
+            print(f"[CopilotCLI] exit {result.returncode}: {stderr}", file=sys.stderr)
+
+    except subprocess.TimeoutExpired:
+        print(f"[CopilotCLI] Timed out after {timeout}s", file=sys.stderr)
+    except Exception as e:
+        print(f"[CopilotCLI] Error: {e}", file=sys.stderr)
+
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Drop-in client that quacks like AzureOpenAI
+# ---------------------------------------------------------------------------
+
+class _Completions:
+    """Mimics openai.resources.chat.Completions so that
+    ``client.chat.completions.create(model=..., messages=...)``
+    works identically to the Azure / TRAPI path."""
+
+    @staticmethod
+    def _extract_json(text: str) -> str:
+        """Extract JSON from Copilot CLI response that may contain markdown
+        fences, preamble text, or other wrapper content.
+
+        Tries (in order):
+          1. ```json ... ``` fenced block
+          2. ``` ... ``` generic fenced block
+          3. First { or [ to last } or ]  (greedy)
+          4. Original text as-is
+        """
+        import re
+
+        if not text or not text.strip():
+            return text
+
+        # 1. ```json ... ```
+        m = re.search(r'```json\s*\n?([\s\S]*?)```', text)
+        if m:
+            return m.group(1).strip()
+
+        # 2. ``` ... ```
+        m = re.search(r'```\s*\n?([\s\S]*?)```', text)
+        if m:
+            candidate = m.group(1).strip()
+            if candidate and candidate[0] in '{[':
+                return candidate
+
+        # 3. First { or [ ... last } or ]
+        first = None
+        for i, c in enumerate(text):
+            if c in '{[':
+                first = i
+                break
+        if first is not None:
+            last = None
+            target = '}' if text[first] == '{' else ']'
+            for i in range(len(text) - 1, first, -1):
+                if text[i] == target:
+                    last = i
+                    break
+            if last is not None:
+                return text[first:last + 1]
+
+        # 4. Return as-is
+        return text
+
+    def create(self, *, model: str = "", messages: list = None, **kwargs):
+        _verify_cli()
+        prompt = _flatten_messages(messages or [])
+
+        # If caller requests JSON output, add a hint to the prompt
+        response_format = kwargs.get("response_format", None)
+        wants_json = (isinstance(response_format, dict)
+                      and response_format.get("type") == "json_object")
+        if wants_json:
+            prompt += "\n\nIMPORTANT: Respond with ONLY valid JSON. No markdown fences, no explanation text."
+
+        start = time.perf_counter()
+        text = _call_cli(prompt)
+        elapsed = time.perf_counter() - start
+
+        # If JSON was requested, extract it from any wrapper text
+        if wants_json and text:
+            text = self._extract_json(text)
+
+        # Build a response object shaped like the OpenAI SDK response
+        choice = SimpleNamespace(
+            message=SimpleNamespace(content=text, role="assistant"),
+            index=0,
+            finish_reason="stop",
+        )
+        usage = SimpleNamespace(
+            prompt_tokens=len(prompt) // 4,
+            completion_tokens=len(text) // 4,
+            total_tokens=(len(prompt) + len(text)) // 4,
+        )
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "copilot-cli",
+            _elapsed=elapsed,
+        )
+
+
+class _Chat:
+    def __init__(self):
+        self.completions = _Completions()
+
+
+class CopilotCLIClient:
+    """Mimics ``openai.AzureOpenAI`` just enough for AgentRx."""
+
+    def __init__(self, **_kwargs):
+        _verify_cli()
+        self.chat = _Chat()
+
+
+def copilot_mk_client(**_kwargs) -> CopilotCLIClient:
+    """Factory — same call signature as ``LLMAgentAzure.azure_mk_client()``."""
+    return CopilotCLIClient()
+
+
+# ---------------------------------------------------------------------------
+# LLMAgent subclass used by judge.py  (it inherits from the agent class)
+# ---------------------------------------------------------------------------
+
+class LLMAgent:
+    """Drop-in replacement for ``llm_clients.azure.LLMAgent`` and
+    ``llm_clients.trapi.LLMAgent`` so the Judge can subclass it."""
+
+    def __init__(self, api_version=None, model_name=None,
+                 model_version=None, deployment_name=None, **_kwargs):
+        self.api_version = api_version or ""
+        self.model_name = model_name or "copilot-cli"
+        self.model_version = model_version or ""
+        self.deployment_name = deployment_name or ""
+        self.endpoint = "copilot-cli"
+        self.last_call_telemetry = None
+        self.client = CopilotCLIClient()
+
+    def get_llm_response(self, messages):
+        start_timestamp = datetime.now()
+        start_time = time.perf_counter()
+
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=messages,
+        )
+
+        end_time = time.perf_counter()
+        end_timestamp = datetime.now()
+        execution_time_sec = round(end_time - start_time, 4)
+
+        usage = response.usage
+        prompt_tokens = getattr(usage, "prompt_tokens", 0)
+        completion_tokens = getattr(usage, "completion_tokens", 0)
+        total_tokens = getattr(usage, "total_tokens", 0)
+
+        if metrics:
+            token_usage = metrics.TokenUsage(
+                prompt_tokens=prompt_tokens,
+                output_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+            time_info = metrics.TimingInfo(
+                start_time=start_timestamp,
+                end_time=end_timestamp,
+                execution_time_sec=execution_time_sec,
+            )
+            self.last_call_telemetry = metrics.LLMCallTelemetry(
+                tokens=token_usage,
+                time=time_info,
+                model_name=self.model_name,
+                instance=self.endpoint,
+            )
+
+        return response
+
+    @staticmethod
+    def copilot_mk_client() -> CopilotCLIClient:
+        return copilot_mk_client()

--- a/src/llm_clients/copilot_cli.py
+++ b/src/llm_clients/copilot_cli.py
@@ -136,7 +136,14 @@ def _flatten_messages(messages: List[Dict[str, str]]) -> str:
 
 
 COPILOT_TIMEOUT = int(os.getenv("AGENT_VERIFY_COPILOT_TIMEOUT", "600"))
-COPILOT_MODEL = os.getenv("COPILOT_MODEL", "claude-opus-4.6")  # default: Opus 4.6; override via env var
+# Model selection for Copilot CLI. Prefers AGENT_VERIFY_COPILOT_MODEL (standard naming),
+# falls back to COPILOT_MODEL for backward compat. See `copilot --help` for supported
+# models (e.g. claude-opus-4.6, claude-sonnet-4.5, gpt-5, gpt-5-mini).
+COPILOT_MODEL = (
+    os.getenv("AGENT_VERIFY_COPILOT_MODEL")
+    or os.getenv("COPILOT_MODEL")
+    or "claude-opus-4.6"
+)
 
 
 # Max characters safe for the -p flag on Windows (WinError 206 above this).

--- a/src/pipeline/globals.py
+++ b/src/pipeline/globals.py
@@ -58,9 +58,9 @@ MAGENTIC_TASK_IDS = [
     "f88066d274e265edd6cd9d61cd80a41accb3a14baf2297652fdd05cdf716d455",
 ]
 
-DEFAULT_ENDPOINT = os.environ.get("AGENT_VERIFY_ENDPOINT_TYPE", "azure")  # "azure" or "trapi"
-if DEFAULT_ENDPOINT not in ("azure", "trapi"):
-    raise ValueError(f"AGENT_VERIFY_ENDPOINT_TYPE must be 'azure' or 'trapi', got: {DEFAULT_ENDPOINT!r}")
+DEFAULT_ENDPOINT = os.environ.get("AGENT_VERIFY_ENDPOINT_TYPE", "copilot")  # "copilot", "azure", or "trapi"
+if DEFAULT_ENDPOINT not in ("copilot", "azure", "trapi"):
+    raise ValueError(f"AGENT_VERIFY_ENDPOINT_TYPE must be 'copilot', 'azure', or 'trapi', got: {DEFAULT_ENDPOINT!r}")
 
 TRAPI_INSTANCE = os.environ.get("AGENT_VERIFY_TRAPI_INSTANCE", "")  # See https://aka.ms/trapi/models for the instance name
 TRAPI_ENDPOINT_PREFIX = os.environ.get("AGENT_VERIFY_TRAPI_ENDPOINT_PREFIX", "https://trapi.research.microsoft.com/")
@@ -149,6 +149,7 @@ METRICS_OUTPUT_DIR_PATH = 'metrics_output'
 JUDGE_CONTEXT_DIR_PATH = 'judge_context'
 DEDUPLICATED_VIOLATIONS_DIR_PATH = 'deduplicated_violations'
 
+COPILOT_ENDPOINT = "copilot"
 AZURE_ENDPOINT = "azure"
 TRAPI_ENDPOINT = "trapi"
 


### PR DESCRIPTION
## New Feature: Copilot CLI Endpoint (--endpoint copilot)

Adds GitHub Copilot CLI as a zero-config LLM backend for AgentRx, alongside Azure and TRAPI.

### Changes
- **New file:** \src/llm_clients/copilot_cli.py\ - Drop-in LLM client using \copilot.exe\
  - Stdin piping for prompts up to 200K+ chars (bypasses Windows 32K arg limit)
  - Auto-resolves copilot.exe vs .ps1 bootstrapper on Windows
  - Extracts JSON from markdown fences in CLI responses
  - Safe \__import__\ allowlist for sandbox compatibility
  - LLMAgent class for judge inheritance
- **Updated all 6 LLM branch sites:** globals, run.py, trajectory_ir, static/dynamic generators, checker, judge
- **New \--dynamic-mode\ flag:** \stepbystep\ (default) or \oneshot\
- **.env.example** updated with copilot endpoint documentation

### Bug Fixes
1. **Dynamic invariant parser:** Accept JSON arrays (\[...]\) from LLM (both step-by-step and one-shot)
2. **Checker sandbox:** Add safe \__import__\ to builtins (fixes \import json\ in generated checks)
3. **Trigger matching:** Handle range \step_index\ like \20-21\
4. **Judge:** Use IR file directly to avoid re-normalization (was losing 28/29 trajectories)
5. **Static invariant parser:** Accept arrays (same as dynamic fix)
6. **Checker extract_invariants:** Also check \dynamic_invariants\ key

### Testing
- Tested on 29 failed tau-retail trajectories with ground truth
- Category accuracy: 17.2% | Step accuracy within +-3: 72.4%
- 93 violations detected across 26/29 trajectories
- 104 dynamic invariants generated across 29/29 trajectories