### PR TITLE
Fix end-to-end pipeline bugs found post-merge of #19

### DIFF
--- a/agentrx/invariants/checker.py
+++ b/agentrx/invariants/checker.py
@@ -236,16 +236,30 @@ class AllVerifier:
 
         out: List[Dict[str, Any]] = []
 
+        def _looks_like_invariant(d: Dict[str, Any]) -> bool:
+            # Real invariants have these fields; per-step wrappers do not.
+            return isinstance(d, dict) and (
+                "assertion_name" in d or "event_trigger" in d or "check_type" in d
+            )
+
         def add_payload(x: Any) -> None:
             if x is None:
                 return
             if isinstance(x, dict):
+                # If this is a per-step wrapper {step_num, decision, invariant: [...]},
+                # recurse into the nested 'invariant'/'invariants' list. Otherwise
+                # treat the dict as a leaf invariant object.
+                if not _looks_like_invariant(x) and (
+                    "invariant" in x or "invariants" in x
+                ):
+                    add_payload(x.get("invariant"))
+                    add_payload(x.get("invariants"))
+                    return
                 out.append(x)
                 return
             if isinstance(x, list):
                 for y in x:
-                    if isinstance(y, dict):
-                        out.append(y)
+                    add_payload(y)
 
         # Load static invariants from static_invariants_used (stored as JSON string)
         static_str = data.get("static_invariants_used")
@@ -342,28 +356,37 @@ class AllVerifier:
 
     def _step_matches_trigger(self, trig_step: Any, step_pos: int, step_obj: Dict[str, Any]) -> bool:
         """
-        We DO NOT rewrite trigger.step_index. But to avoid obvious off-by-one pains,
-        we accept a match if:
-          - trigger_step == step_pos
-          - OR trigger_step == step_pos + 1
-          - OR trigger_step == step_obj.get("index") (if present and int-ish)
-          - OR trigger_step is a range like "20-21" and step_pos/index falls in it
+        Match a trigger.step_index against the current step.
+
+        The dynamic-invariant generator is shown the IR with each step's
+        ``index`` field (1-indexed) and emits ``trigger.step_index`` using
+        that same numbering.  So when the step has an ``index`` field, that
+        is the authoritative match — we MUST NOT also accept ``step_pos``
+        (0-indexed) or ``step_pos + 1`` because that would make every
+        trigger fire at two adjacent steps (off-by-one duplicates).
+
+        Match semantics (in priority order):
+          1. trigger in (None, "", "*")           -> always match
+          2. step_obj has int ``index``           -> match iff trigger == index
+          3. step_obj has no usable ``index``     -> fall back to step_pos
+                                                     OR step_pos + 1 (legacy
+                                                     IR without index field)
+          4. trigger is a range "lo-hi"           -> apply same precedence
         """
         if trig_step in (None, "", "*"):
             return True
 
         step_index_field = safe_int(step_obj.get("index"))
 
-        # Try simple integer match first
+        # Try simple integer match
         t = safe_int(trig_step)
         if t is not None:
-            if t == step_pos:
-                return True
-            if t == step_pos + 1:
-                return True
-            if step_index_field is not None and t == step_index_field:
-                return True
-            return False
+            if step_index_field is not None:
+                # Authoritative path: IR has 1-indexed `index`, only match
+                # against it. No off-by-one fallback.
+                return t == step_index_field
+            # Legacy IR (no `index`): permissive 0-/1-indexed fallback
+            return t == step_pos or t == step_pos + 1
 
         # Handle range triggers like "20-21", "15-20"
         trig_str = str(trig_step).strip()
@@ -372,13 +395,10 @@ class AllVerifier:
             lo = safe_int(parts[0].strip())
             hi = safe_int(parts[1].strip())
             if lo is not None and hi is not None:
-                # Check both step_pos (0-based) and step.index (1-based)
-                if lo <= step_pos <= hi:
-                    return True
-                if lo <= step_pos + 1 <= hi:
-                    return True
-                if step_index_field is not None and lo <= step_index_field <= hi:
-                    return True
+                if step_index_field is not None:
+                    return lo <= step_index_field <= hi
+                # Legacy IR fallback
+                return (lo <= step_pos <= hi) or (lo <= step_pos + 1 <= hi)
 
         return False
 
@@ -1233,13 +1253,21 @@ def main():
         }
 
         # Initialize the dynamic verifier if dynamic invariants for that trajectory exist, else skip dynamic invariant verification
-        dynamic_invariants_file = os.path.join(dynamic_invariants_dir, f"out_{task_id}.json")
+        # Try both step-by-step (out_{id}.json) and one-shot (out_{id}_oneshot.json) filenames.
+        dynamic_invariants_file = None
+        for candidate in (
+            os.path.join(dynamic_invariants_dir, f"out_{task_id}.json"),
+            os.path.join(dynamic_invariants_dir, f"out_{task_id}_oneshot.json"),
+        ):
+            if os.path.exists(candidate):
+                dynamic_invariants_file = candidate
+                break
         dynamic_verifier = None
-        if os.path.exists(dynamic_invariants_file):
+        if dynamic_invariants_file:
             print(f"Using dynamic invariants file: {dynamic_invariants_file} for task_id={task_id}")
             dynamic_verifier = AllVerifier(invariants_path=dynamic_invariants_file, policy_document_path=policy_document_path, client=args.client)
         else:
-            dbg(f"Dynamic invariants file not found: {dynamic_invariants_file}, skipping dynamic verification for task_id={task_id}")
+            dbg(f"Dynamic invariants file not found for task_id={task_id} in {dynamic_invariants_dir}, skipping dynamic verification")
 
         dbg(f"=== TRAJ {i} task_id={task_id} trajectory_id={traj.get('trajectory_id')!r} ===")
 

--- a/agentrx/judge/judge.py
+++ b/agentrx/judge/judge.py
@@ -415,15 +415,15 @@ def load_few_shot_examples():
                 with open(path, 'r') as f:
                     examples[category_num] = json.load(f)
                     loaded_count += 1
-                    print(f"[FEW-SHOT] ✓ Loaded example for category {category_num}: {filename}")
+                    print(f"[FEW-SHOT] [OK] Loaded example for category {category_num}: {filename}")
             except FileNotFoundError:
                 examples[category_num] = None
                 missing_count += 1
-                print(f"[FEW-SHOT] ✗ Missing example for category {category_num}: {filename}")
+                print(f"[FEW-SHOT] [MISS] Missing example for category {category_num}: {filename}")
             except json.JSONDecodeError as e:
                 examples[category_num] = None
                 missing_count += 1
-                print(f"[FEW-SHOT] ✗ Invalid JSON in example for category {category_num}: {filename} - {e}")
+                print(f"[FEW-SHOT] [ERR] Invalid JSON in example for category {category_num}: {filename} - {e}")
         else:
             examples[category_num] = None
             skipped_count += 1
@@ -999,16 +999,16 @@ def load_invariant_violation_context(task_id):
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
             context_data = json.load(f)
-            print(f"[CONTEXT] ✓ Loaded violation context for task {task_id}: {file_path}")
+            print(f"[CONTEXT] [OK] Loaded violation context for task {task_id}: {file_path}")
             return context_data
     except FileNotFoundError:
-        print(f"[CONTEXT] ✗ No violation context file found for task {task_id}: {file_path}")
+        print(f"[CONTEXT] [MISS] No violation context file found for task {task_id}: {file_path}")
         return None
     except json.JSONDecodeError as e:
-        print(f"[CONTEXT] ✗ Invalid JSON in context file for task {task_id}: {file_path} - {e}")
+        print(f"[CONTEXT] [ERR] Invalid JSON in context file for task {task_id}: {file_path} - {e}")
         return None
     except Exception as e:
-        print(f"[CONTEXT] ✗ Error reading context file for task {task_id}: {file_path} - {e}")
+        print(f"[CONTEXT] [ERR] Error reading context file for task {task_id}: {file_path} - {e}")
         return None
 
 def convert_to_failure_case(case_input):
@@ -1336,6 +1336,14 @@ def analysis(data, output_file_path=None, model_name=None, api_version=None):
             if os.path.exists(output_file_path):
                 with open(output_file_path, 'r') as f:
                     existing_data = json.load(f)
+                # Handle either format:
+                #   - list of per-task dicts (legacy)
+                #   - {"summary": ..., "detailed_results": [...]} (current)
+                if isinstance(existing_data, dict) and "detailed_results" in existing_data:
+                    existing_data = existing_data["detailed_results"]
+                # Fallback: if format is unexpected, prefer the freshly-computed `data`
+                if not isinstance(existing_data, list):
+                    existing_data = data
             else:
                 existing_data = data # Should match
 

--- a/agentrx/llm_clients/copilot_cli.py
+++ b/agentrx/llm_clients/copilot_cli.py
@@ -59,39 +59,112 @@ def _refresh_path():
 
 def _find_copilot_bin() -> str:
     """Locate the real copilot binary, refreshing PATH if needed.
-    
-    Prefers copilot.exe over .ps1/.cmd wrappers on Windows, because
-    the VS Code bootstrapper (copilot.ps1) may shadow the real binary
-    and prompt interactively.
+
+    Cross-platform binary resolution:
+
+    On **Windows** there can be up to 4 different "copilot" entries on PATH:
+      1. VS Code bootstrapper (copilot.ps1 / .bat) — interactive, avoid
+      2. WinGet bootstrapper (copilot.exe ~100MB) — hangs without WinGet
+         runtime context, avoid
+      3. npm-installed shell script (copilot, no extension) — fine on POSIX
+      4. npm-installed cmd wrapper (copilot.cmd) — fine on Windows, this
+         is what we prefer
+
+    On **macOS / Linux** the npm global install puts a plain `copilot`
+    shell wrapper into one of:
+      - /usr/local/bin/copilot                    (Intel Mac, system npm)
+      - /opt/homebrew/bin/copilot                 (Apple Silicon Homebrew)
+      - $HOME/.npm-global/bin/copilot             (user-prefix npm)
+      - $HOME/.nvm/versions/node/*/bin/copilot    (nvm-managed node)
+
+    Priority order (all platforms):
+      a) AGENT_VERIFY_COPILOT_BIN env override (absolute path)
+      b) Platform-specific npm global locations (direct file check)
+      c) shutil.which() lookups
+      d) Last-resort fallbacks (with warnings on Windows)
     """
     import shutil
 
     # Always refresh PATH from registry first — Node/npm/winget installs
-    # done after Python started won't be visible otherwise
+    # done after Python started won't be visible otherwise (Windows only)
     _refresh_path()
 
-    # On Windows, look for the .exe explicitly to avoid the VS Code
-    # bootstrapper (.ps1) that requires interactive input
-    if sys.platform == "win32":
-        exe_path = shutil.which("copilot.exe")
-        if exe_path:
-            return exe_path
+    # 1. Explicit override (works on all platforms)
+    override = os.getenv("AGENT_VERIFY_COPILOT_BIN")
+    if override and os.path.exists(override):
+        return override
 
-    # Fallback to whatever "copilot" resolves to
+    if sys.platform == "win32":
+        # 2a. Direct check for npm global install on Windows
+        appdata = os.getenv("APPDATA")
+        if appdata:
+            npm_cmd = os.path.join(appdata, "npm", "copilot.cmd")
+            if os.path.exists(npm_cmd):
+                return npm_cmd
+
+        # 3a. PATH lookup for .cmd (npm-style)
+        cmd_path = shutil.which("copilot.cmd")
+        if cmd_path:
+            return cmd_path
+
+        # 4a. .exe — only if not the WinGet shim
+        exe_path = shutil.which("copilot.exe")
+        if exe_path and "WinGet" not in exe_path:
+            return exe_path
+    else:
+        # 2b. Direct check for common npm global locations on macOS / Linux
+        home = os.path.expanduser("~")
+        candidates = [
+            "/usr/local/bin/copilot",
+            "/opt/homebrew/bin/copilot",
+            os.path.join(home, ".npm-global", "bin", "copilot"),
+            os.path.join(home, ".local", "bin", "copilot"),
+        ]
+        # nvm: pick the highest-version node bin if present
+        nvm_root = os.path.join(home, ".nvm", "versions", "node")
+        if os.path.isdir(nvm_root):
+            try:
+                nodes = sorted(os.listdir(nvm_root), reverse=True)
+                for node_ver in nodes:
+                    candidates.append(
+                        os.path.join(nvm_root, node_ver, "bin", "copilot")
+                    )
+            except OSError:
+                pass
+        for c in candidates:
+            if os.path.exists(c) and os.access(c, os.X_OK):
+                return c
+
+    # Fallback to whatever "copilot" resolves to via PATH (any OS)
     path = shutil.which("copilot")
     if path:
         return path
 
+    # Absolute last resort: WinGet exe (will likely hang, but better to
+    # surface a real error than silently fail)
+    if sys.platform == "win32":
+        exe_path = shutil.which("copilot.exe")
+        if exe_path:
+            print(f"[CopilotCLI] Warning: only WinGet shim found at {exe_path}; "
+                  f"install via `npm i -g @github/copilot` for reliability",
+                  file=sys.stderr)
+            return exe_path
+
     raise RuntimeError(
         "'copilot' CLI not found on PATH.\n"
-        "Install: https://docs.github.com/en/copilot/using-github-copilot/"
-        "using-github-copilot-in-the-command-line\n"
-        "Or:  winget install GitHub.Copilot"
+        "Install: npm install -g @github/copilot\n"
+        "Or set AGENT_VERIFY_COPILOT_BIN to the full path."
     )
 
 
 def _verify_cli():
-    """Check once that the copilot binary is reachable."""
+    """Check once that the copilot binary is reachable.
+
+    Cold-start of copilot.exe can take 30-60s on first invocation (loading
+    Node, auth check, etc.), so we use a generous timeout. If --version
+    hangs, we still mark the binary as verified — _call_cli has its own
+    timeout and will surface real failures there.
+    """
     global _CLI_VERIFIED, _COPILOT_BIN
     if _CLI_VERIFIED:
         return
@@ -102,7 +175,8 @@ def _verify_cli():
             capture_output=True,
             encoding="utf-8",
             errors="replace",
-            timeout=15,
+            stdin=subprocess.DEVNULL,  # never let CLI block on stdin
+            timeout=60,
         )
         if result.returncode == 0:
             print(f"[CopilotCLI] Found: {result.stdout.strip()}")
@@ -113,6 +187,11 @@ def _verify_cli():
         raise RuntimeError(
             f"'copilot' binary not executable at: {_COPILOT_BIN}"
         )
+    except subprocess.TimeoutExpired:
+        # Don't abort the whole pipeline just because --version is slow.
+        # Real LLM calls have their own (longer) timeouts.
+        print(f"[CopilotCLI] Warning: --version timed out; continuing anyway "
+              f"(binary at {_COPILOT_BIN})", file=sys.stderr)
     _CLI_VERIFIED = True
 
 

--- a/run.py
+++ b/run.py
@@ -30,6 +30,14 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+# Force UTF-8 stdout/stderr on Windows so emoji/unicode prints don't crash
+# the pipeline with UnicodeEncodeError (cp1252 default)
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
 REPO_ROOT = Path(__file__).resolve().parent
 
 import agentrx.pipeline.globals as g
@@ -332,8 +340,16 @@ def run_check(ir_path: str, run_dir: str, domain: str, endpoint: str,
 
         # Dynamic check (if dynamic invariants exist for this trajectory)
         if dynamic_invariants_dir:
-            dyn_file = os.path.join(dynamic_invariants_dir, f"out_{task_id}.json")
-            if os.path.exists(dyn_file):
+            # Try both step-by-step (out_{id}.json) and one-shot (out_{id}_oneshot.json) names
+            dyn_file = None
+            for cand in (
+                os.path.join(dynamic_invariants_dir, f"out_{task_id}.json"),
+                os.path.join(dynamic_invariants_dir, f"out_{task_id}_oneshot.json"),
+            ):
+                if os.path.exists(cand):
+                    dyn_file = cand
+                    break
+            if dyn_file:
                 dyn_verifier = AllVerifier(
                     invariants_path=dyn_file,
                     policy_document_path=policy_path,
@@ -515,6 +531,8 @@ Examples:
                         help="Run ONLY this stage")
     parser.add_argument("--from-stage", default=None, choices=STAGES,
                         help="Resume from this stage (skips earlier stages)")
+    parser.add_argument("--skip-static", action="store_true",
+                        help="Skip static invariant generation (use empty static set; only dynamic invariants will drive checking)")
     parser.add_argument("--skip-dynamic", action="store_true",
                         help="Skip dynamic invariant generation (faster)")
     parser.add_argument("--dynamic-mode", default="stepbystep", choices=["stepbystep", "oneshot"],
@@ -619,6 +637,8 @@ def run_pipeline(input_path: str, args):
 
     if args.skip_dynamic:
         stages_to_run = [s for s in stages_to_run if s != "dynamic"]
+    if args.skip_static:
+        stages_to_run = [s for s in stages_to_run if s != "static"]
     if args.skip_judge:
         stages_to_run = [s for s in stages_to_run if s not in ("judge", "report")]
     # Print plan
@@ -654,10 +674,17 @@ def run_pipeline(input_path: str, args):
             state["completed_stages"] = list(set(state.get("completed_stages", [])) | {"static"})
             save_state(run_dir, state)
         elif not os.path.exists(static_inv_path) and any(s in stages_to_run for s in ["check", "dynamic"]):
-            print("[INFO] Running static invariant stage (required by later stages)")
-            static_inv_path = run_static(input_path, run_dir, domain, args.endpoint, state)
-            state["completed_stages"] = list(set(state.get("completed_stages", [])) | {"static"})
-            save_state(run_dir, state)
+            if args.skip_static:
+                print("[INFO] --skip-static set: writing empty static_invariants.json")
+                with open(static_inv_path, "w", encoding="utf-8") as f:
+                    json.dump({"invariants": []}, f, indent=2)
+                state["completed_stages"] = list(set(state.get("completed_stages", [])) | {"static"})
+                save_state(run_dir, state)
+            else:
+                print("[INFO] Running static invariant stage (required by later stages)")
+                static_inv_path = run_static(input_path, run_dir, domain, args.endpoint, state)
+                state["completed_stages"] = list(set(state.get("completed_stages", [])) | {"static"})
+                save_state(run_dir, state)
 
         # --- Dynamic Invariants ---
         if "dynamic" in stages_to_run:


### PR DESCRIPTION
## Summary

Five bug fixes uncovered while running the full pipeline end-to-end on Windows + Python 3.14 + GitHub Copilot CLI after PR #19 was merged.

## Bugs fixed

**1. Step-index matcher off-by-one** (src/invariants/checker.py)
IR has BOTH 0-indexed step_pos and 1-indexed step.index. Matcher accepted either, so every dynamic invariant trigger fired at two adjacent steps. Fixed: strict match against step.index when present.

**2. Unicode charmap crash in judge** (src/judge/judge.py)
Python 3.14 default cp1252 stdout on Windows could not encode the check/cross marks; every task in the judge stage crashed. Replaced with [OK]/[ERR]/[MISS], plus UTF-8 stdout reconfigure in run.py.

**3. Dynamic-invariant filename mismatch** (src/invariants/checker.py + run.py)
One-shot generator writes out_{id}_oneshot.json, but checker only looked for out_{id}.json so 0 dynamic checks ran. Now checks both filenames.

**4. WinGet copilot.exe shim hang** (src/llm_clients/copilot_cli.py)
shutil.which resolved to WinGet's bootstrapper which hangs without WinGet runtime context. New cross-platform resolver: Windows prefers npm copilot.cmd, macOS/Linux tries Homebrew + npm-global + nvm. Respects AGENT_VERIFY_COPILOT_BIN env override on all platforms. _verify_cli now tolerates --version timeout instead of aborting.

**5. Judge analysis file-format crash** (src/judge/judge.py)
analysis() crashed with str has no attribute get when re-reading an existing dict-format run file. Now detects dict vs list and extracts detailed_results.

## New flag

Added --skip-static to run.py for runs where only dynamic invariants should drive checking.

## Validation

Smoke-tested end-to-end on tau-retail task 12: category INSTRUCTION_OR_PLAN_ADHERENCE_FAILURE @ Step 19 matches ground truth exactly, step distance 0, 105s runtime.
