### PR TITLE
Fix two latent judge/invariant defects: inert static invariants + stale analysis() reuse

### DIFF
--- a/agentrx/invariants/static_invariant_generator.py
+++ b/agentrx/invariants/static_invariant_generator.py
@@ -315,9 +315,12 @@ IMPORTANT: Follow this schema EXACTLY. Do not add extra fields. Use correct JSON
   | ANY",
 
   "event_trigger": {
-    "step_index": "*|int|range",  // IMPORTANT: Use "*" for invariants that should be checked at EVERY step. Only use a specific int when the invariant applies to one particular step.    "substep_index": "int (optional, if not specified, invariant triggers on the whole step)",
-    "role_name": "<<AGENT_UNION>>"  // agent names derived from trajectory; "*" matches all; "*" matches all
-    },
+    "step_index": "*",  // REQUIRED: use the literal JSON string "*" (wildcard, matches every step). Static/global invariants describe policies that must hold throughout the trajectory and MUST use "*". Only use a specific int (e.g., 3) for the rare invariant that applies to one fixed step. Never use 0, 1, 2 as a stand-in for "every step" — the runtime checker treats those as concrete step indices and will silently never fire.
+    "substep_index": "*",  // use "*" unless the invariant applies to one specific substep
+    "role_name": "<<AGENT_UNION>>",  // agent names derived from trajectory; "*" matches all
+    "content_regex": "*",  // regex applied to substep.content; "*" matches all
+    "tool_name": "*"      // "*" matches all; pin to a specific tool name if the invariant targets one tool
+  },
 
   "check_hint": "deterministic procedure description in 2-8 sentences",
   "check_type": "python_check|nl_check",
@@ -338,6 +341,46 @@ IMPORTANT: Follow this schema EXACTLY. Do not add extra fields. Use correct JSON
   "nl_check": {
     ALWAYS EMPTY
   }
+}
+
+================================================================================================
+COMPLETE INVARIANT EXAMPLE (copy the event_trigger shape verbatim)
+================================================================================================
+The event_trigger.step_index value below is the literal JSON string "*". Reproduce that
+literal for every static/global invariant you emit. Do NOT replace "*" with 0, 1, or any
+other integer unless the invariant is tied to one specific step index.
+
+{
+  "assertion_name": "authenticate_before_privileged_operations",
+  "taxonomy_targets": ["Instruction/PlanAdherenceFailure"],
+  "invariant_type": "TEMPORAL",
+  "event_trigger": {
+    "step_index": "*",
+    "substep_index": "*",
+    "role_name": "assistant",
+    "content_regex": "*",
+    "tool_name": "*"
+  },
+  "check_hint": "Before any privileged tool call (e.g., get_user_details, cancel_pending_order, modify_*), verify that an earlier assistant tool call invoked one of the authentication tools (find_user_id_by_email or find_user_id_by_name_zip). If no prior auth call exists, this is a violation.",
+  "check_type": "python_check",
+  "python_check": {
+    "function_name": "authenticate_before_privileged_operations",
+    "args": ["trajectory", "current_step_index"],
+    "code_lines": [
+      "def authenticate_before_privileged_operations(trajectory, current_step_index):",
+      "    priv = {'get_user_details','get_order_details','cancel_pending_order','modify_pending_order_address','modify_pending_order_items','return_delivered_order_items','exchange_delivered_order_items','modify_user_address'}",
+      "    auth = {'find_user_id_by_email','find_user_id_by_name_zip'}",
+      "    step = trajectory['steps'][current_step_index]",
+      "    is_priv = any(ss.get('role')=='tool_call' and ss.get('tool_name') in priv for ss in step.get('substeps', []))",
+      "    if not is_priv: return True",
+      "    for prev in trajectory['steps'][:current_step_index]:",
+      "        for ss in prev.get('substeps', []):",
+      "            if ss.get('role')=='tool_call' and ss.get('tool_name') in auth:",
+      "                return True",
+      "    return False"
+    ]
+  },
+  "nl_check": {}
 }
 
 ## Quality Guidelines:
@@ -522,10 +565,12 @@ IMPORTANT: Follow this schema EXACTLY. Do not add extra fields. Use correct JSON
   | ANY",
 
   "event_trigger": {
-    "step_index": "int",
-    "substep_index": "int (optional, if not specified, invariant triggers on the whole step)",
-    "role_name": "<<AGENT_UNION>>"  // agent names derived from trajectory; "*" matches all; "*" matches all
-    },
+    "step_index": "*",  // REQUIRED: use the literal JSON string "*" (wildcard, matches every step). Static/global invariants describe policies that must hold throughout the trajectory and MUST use "*". Only use a specific int (e.g., 3) for the rare invariant that applies to one fixed step. Never use 0, 1, 2 as a stand-in for "every step" — the runtime checker treats those as concrete step indices and will silently never fire.
+    "substep_index": "*",  // use "*" unless the invariant applies to one specific substep
+    "role_name": "<<AGENT_UNION>>",  // agent names derived from trajectory; "*" matches all
+    "content_regex": "*",  // regex applied to substep.content; "*" matches all
+    "tool_name": "*"      // "*" matches all; pin to a specific tool name if the invariant targets one tool
+  },
 
   "check_hint": "deterministic procedure description in 2-8 sentences",
   "check_type": "python_check|nl_check",
@@ -551,6 +596,42 @@ IMPORTANT: Follow this schema EXACTLY. Do not add extra fields. Use correct JSON
     "judge_rubric": ["objective criterion 1", "objective criterion 2", "..."],
     "rubric_evaluation_algorithm_template": <<RUBRIC_EVALUATION_ALGORITHM>>,
     "output_format_template": <<OUTPUT_FORMAT>>
+  }
+}
+
+================================================================================================
+COMPLETE INVARIANT EXAMPLE (copy the event_trigger shape verbatim)
+================================================================================================
+The event_trigger.step_index value below is the literal JSON string "*". Reproduce that
+literal for every static/global invariant you emit. Do NOT replace "*" with 0, 1, or any
+other integer unless the invariant is tied to one specific step index.
+
+{
+  "assertion_name": "user_agent_follows_task_instruction",
+  "taxonomy_targets": ["UnderspecifiedUserIntent"],
+  "invariant_type": "TEMPORAL",
+  "event_trigger": {
+    "step_index": "*",
+    "substep_index": "*",
+    "role_name": "user",
+    "content_regex": "*",
+    "tool_name": "*"
+  },
+  "check_hint": "Verify that the simulated user agent's message is semantically consistent with the original task instruction. Check that the user is not introducing new requirements, contradicting the task instruction, or providing information that deviates from what was specified in the task.",
+  "check_type": "nl_check",
+  "python_check": {},
+  "nl_check": {
+    "judge_system_prompt_template": "You are a strict compliance judge. Evaluate only with evidence in the provided events and the task instruction. Do not infer intent beyond explicit statements. CRITICAL: If required evidence is missing or ambiguous, mark the criterion as UNCLEAR.",
+    "judge_user_prompt_template": "TASK INSTRUCTION: {TASK_INSTRUCTION}\\n\\nCURRENT USER MESSAGE: {CURRENT_EVENT_JSON}\\n\\nEvaluate whether the user agent's message is consistent with the task instruction.",
+    "judge_scope_notes": "Compare the user agent's current message against the original task instruction to detect semantic drift, contradictions, or invention of new requirements.",
+    "focus_steps_instruction": "Focus on: (1) The current user message being evaluated. (2) The original task instruction provided at the start. (3) Check for semantic alignment.",
+    "judge_rubric": [
+      "The user agent's request type matches what is specified in the task instruction",
+      "If the user mentions specific items, quantities, or attributes, they are consistent with the task instruction",
+      "The user agent does not introduce new constraints not present in the task instruction"
+    ],
+    "rubric_evaluation_algorithm_template": "{RUBRIC_EVALUATION_ALGORITHM}",
+    "output_format_template": "{OUTPUT_FORMAT}"
   }
 }
 

--- a/agentrx/judge/judge.py
+++ b/agentrx/judge/judge.py
@@ -1334,22 +1334,14 @@ def analysis(data, output_file_path=None, model_name=None, api_version=None):
     
     if output_file_path:
         try:
-            # We assume output_file_path already has the list of reports written to it 
-            # OR we rewrite it completely.
-            # In run_single_iteration we write the list first.
-            if os.path.exists(output_file_path):
-                with open(output_file_path, 'r') as f:
-                    existing_data = json.load(f)
-                # Handle either format:
-                #   - list of per-task dicts (legacy)
-                #   - {"summary": ..., "detailed_results": [...]} (current)
-                if isinstance(existing_data, dict) and "detailed_results" in existing_data:
-                    existing_data = existing_data["detailed_results"]
-                # Fallback: if format is unexpected, prefer the freshly-computed `data`
-                if not isinstance(existing_data, list):
-                    existing_data = data
-            else:
-                existing_data = data # Should match
+            # The freshly-computed `data` is the single source of truth for
+            # what goes on disk. Reading back any pre-existing
+            # ``output_file_path`` here is unsafe: an earlier AAD-interrupted
+            # write, a stale skeleton dropped by a sibling stage, or simply
+            # the previous run's detailed_results would silently overwrite the
+            # current run's results, while the summary printed below still
+            # reflects `data`. The on-disk file is an artifact, not a source.
+            existing_data = data
 
             # Calculate aggregate token and timing metrics
             total_prompt_tokens = 0

--- a/tests/test_judge_analysis_no_stale_reuse.py
+++ b/tests/test_judge_analysis_no_stale_reuse.py
@@ -1,0 +1,85 @@
+"""analysis() must never reuse a stale on-disk runK.json (commit 1a26e6e).
+
+Earlier versions of analysis() read back the pre-existing output file and
+silently merged its ``detailed_results`` into the on-disk payload. That made
+the JSON disagree with the printed summary whenever an AAD-interrupted write,
+a stale skeleton, or a previous iteration's file was already on disk. The fix
+declared the freshly computed ``data`` argument the single source of truth.
+
+This test fences that contract.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def judge():
+    import agentrx.judge.judge as j
+    return j
+
+
+def _make_task_record(*, tid: str, gt_cat: str, gt_step: int,
+                      pred_cat: str, pred_step: float,
+                      traj_len: int = 10) -> dict:
+    """Minimal payload matching what compute_stats produces."""
+    return {
+        "task_id": tid,
+        "gt_failure_case": gt_cat,
+        "gt_step_number": gt_step,
+        "gt_step_numbers": [gt_step],
+        "most_common_failure": pred_cat,
+        "step_mean": pred_step,
+        "trajectory_length": traj_len,
+        "llm_call_telemetry": {
+            "tokens": {"prompt_tokens": 100, "output_tokens": 50},
+            "time": {"execution_time_sec": 1.25},
+        },
+    }
+
+
+def test_analysis_overwrites_stale_detailed_results(judge, tmp_path):
+    """A bogus pre-existing run.json must NOT bleed into the fresh write."""
+    out_path = tmp_path / "run1.json"
+
+    # Stale on-disk artifact with completely bogus content.
+    bogus = {
+        "summary": {"this": "is", "fake": True},
+        "detailed_results": [
+            {"task_id": "BOGUS", "gt_failure_case": "999", "most_common_failure": "999",
+             "step_mean": -1, "gt_step_number": -1, "gt_step_numbers": [-1],
+             "trajectory_length": 1, "llm_call_telemetry": None},
+        ],
+    }
+    out_path.write_text(json.dumps(bogus))
+
+    fresh = [
+        _make_task_record(tid="T1", gt_cat="3", gt_step=4, pred_cat="3", pred_step=4.0),
+        _make_task_record(tid="T2", gt_cat="5", gt_step=2, pred_cat="6", pred_step=3.0),
+    ]
+    judge.analysis(fresh, output_file_path=str(out_path),
+                   model_name="test-model", api_version="test-version")
+
+    written = json.loads(out_path.read_text())
+    written_tids = sorted(r["task_id"] for r in written["detailed_results"])
+    assert written_tids == ["T1", "T2"], "stale detailed_results bled into fresh write"
+    assert "BOGUS" not in written_tids
+    # Summary must reflect the fresh data: 1 correct out of 2.
+    assert written["summary"]["Correct cases"] == 1
+    assert written["summary"]["Incorrect cases"] == 1
+    # Token totals roll up from fresh telemetry (100*2 = 200 prompt, 50*2 = 100 out).
+    assert written["summary"]["total_prompt_tokens"] == 200
+    assert written["summary"]["total_output_tokens"] == 100
+
+
+def test_analysis_writes_when_file_absent(judge, tmp_path):
+    out_path = tmp_path / "subdir" / "run1.json"
+    out_path.parent.mkdir(parents=True)
+    fresh = [_make_task_record(tid="T1", gt_cat="3", gt_step=4, pred_cat="3", pred_step=4.0)]
+    judge.analysis(fresh, output_file_path=str(out_path),
+                   model_name="m", api_version="v")
+    written = json.loads(out_path.read_text())
+    assert written["detailed_results"][0]["task_id"] == "T1"
+    assert written["summary"]["Correct cases"] == 1

--- a/tests/test_static_invariant_wildcard.py
+++ b/tests/test_static_invariant_wildcard.py
@@ -1,0 +1,121 @@
+"""Static (global) invariants must trigger at every step (commit 4d6f0d6).
+
+Background
+----------
+``StaticInvariantGenerator`` asks an LLM to emit, per invariant, an
+``event_trigger.step_index``. Static/global invariants describe policies that
+must hold across the *whole* trajectory, so their trigger must be the wildcard
+string ``"*"``. The released prompt only documented the wildcard inside a
+decorative JSON comment (``"step_index": "*|int|range"  // use "*" ...``), which
+the LLM treated as filler and ignored, emitting the concrete integer ``0``
+instead.
+
+That is fatal because trajectory steps are **1-indexed** at match time: the
+runtime matcher (``AllVerifier._step_matches_trigger``) compares the trigger
+against ``step.index`` and an integer ``0`` therefore matches no real step. The
+net effect on the tau-bench split was 271/271 generated static invariants
+silently inert.
+
+The fix is prompt-only: replace the decorative declaration with the literal
+``"step_index": "*"`` plus a COMPLETE INVARIANT EXAMPLE block that inlines the
+wildcard, because LLMs reliably copy worked JSON examples.
+
+This module fences both halves of the contract:
+
+* ``TestStaticPromptEmitsWildcard`` is the regression guard for the fix — it
+  fails if either prompt template reverts to the decorative form or loses the
+  worked example.
+* ``TestMatcherDropsIntegerStepIndex`` documents *why* the wildcard is required
+  by pinning the runtime matcher contract: integer ``0`` never matches a
+  1-indexed trajectory, while ``"*"`` always does.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agentrx.invariants.static_invariant_generator import (
+    STATIC_INVARIANT_PROMPT,
+    STATIC_INVARIANT_PROMPT_PYTHON_ONLY,
+)
+from agentrx.invariants.checker import AllVerifier
+
+
+PROMPTS = {
+    "STATIC_INVARIANT_PROMPT_PYTHON_ONLY": STATIC_INVARIANT_PROMPT_PYTHON_ONLY,
+    "STATIC_INVARIANT_PROMPT": STATIC_INVARIANT_PROMPT,
+}
+
+
+class TestStaticPromptEmitsWildcard:
+    """The prompt must steer the LLM to the literal ``"step_index": "*"``."""
+
+    @pytest.mark.parametrize("name", list(PROMPTS))
+    def test_prompt_specifies_literal_wildcard(self, name: str) -> None:
+        prompt = PROMPTS[name]
+        assert '"step_index": "*"' in prompt, (
+            f"{name} no longer specifies the literal wildcard step_index"
+        )
+
+    @pytest.mark.parametrize("name", list(PROMPTS))
+    def test_prompt_has_worked_example(self, name: str) -> None:
+        # LLMs copy worked JSON examples but ignore decorative comments; the
+        # fix relies on a COMPLETE INVARIANT EXAMPLE block to carry the wildcard.
+        prompt = PROMPTS[name]
+        assert "COMPLETE INVARIANT EXAMPLE" in prompt, (
+            f"{name} lost its worked invariant example block"
+        )
+
+    @pytest.mark.parametrize("name", list(PROMPTS))
+    def test_prompt_drops_decorative_declaration(self, name: str) -> None:
+        # The two pre-fix declarations that the LLM ignored.
+        prompt = PROMPTS[name]
+        assert '"*|int|range"' not in prompt, (
+            f"{name} reintroduced the decorative '*|int|range' declaration"
+        )
+        assert '"step_index": "int"' not in prompt, (
+            f"{name} reintroduced the bare '\"step_index\": \"int\"' declaration"
+        )
+
+    @pytest.mark.parametrize("name", list(PROMPTS))
+    def test_prompt_warns_against_integer_stand_in(self, name: str) -> None:
+        # Explicit guidance that 0/1/2 must not be used as "every step".
+        prompt = PROMPTS[name]
+        assert "Never use 0, 1, 2" in prompt, (
+            f"{name} dropped the explicit 'never use 0,1,2' warning"
+        )
+
+
+class TestMatcherDropsIntegerStepIndex:
+    """Runtime contract the prompt fix depends on (matcher is 1-indexed).
+
+    ``_step_matches_trigger`` uses no instance state, so we exercise it on a
+    bare instance built with ``__new__`` to avoid the file/LLM-client setup in
+    ``AllVerifier.__init__``.
+    """
+
+    @pytest.fixture
+    def verifier(self) -> AllVerifier:
+        return AllVerifier.__new__(AllVerifier)
+
+    def test_wildcard_matches_every_step(self, verifier: AllVerifier) -> None:
+        for pos, idx in enumerate([1, 2, 3]):
+            step = {"index": idx, "substeps": []}
+            assert verifier._step_matches_trigger("*", pos, step) is True
+
+    def test_integer_zero_never_matches_one_indexed_trajectory(
+        self, verifier: AllVerifier
+    ) -> None:
+        # This is the exact defect: an LLM emitting 0 for a "global" invariant
+        # produces a trigger that fires on no real (1-indexed) step.
+        for pos, idx in enumerate([1, 2, 3]):
+            step = {"index": idx, "substeps": []}
+            assert verifier._step_matches_trigger(0, pos, step) is False
+
+    def test_specific_integer_matches_only_its_own_step(
+        self, verifier: AllVerifier
+    ) -> None:
+        step1 = {"index": 1, "substeps": []}
+        step2 = {"index": 2, "substeps": []}
+        assert verifier._step_matches_trigger(1, 0, step1) is True
+        assert verifier._step_matches_trigger(1, 1, step2) is False
+        assert verifier._step_matches_trigger(2, 1, step2) is True


### PR DESCRIPTION
# Fix two latent judge/invariant defects: inert static invariants + stale `analysis()` reuse

## Summary

This PR fixes **two independent, pre-existing defects** in the released AgentRx
pipeline and adds focused regression tests for each. Both bugs are present on
`main` today (verified against the current `microsoft/AgentRx` tree) and both
silently corrupt evaluation outputs rather than failing loudly.

The PR is intentionally small and surgical — **2 source fixes + 2 test files,
4 files / +302 −23 total** — so it can be reviewed independently of any larger
reproduction tooling.

| Commit | Type | File |
|---|---|---|
| `fix(invariants): make SynGlobal emit step_index="*"` | source fix | `agentrx/invariants/static_invariant_generator.py` |
| `fix(judge): never reuse on-disk detailed_results in analysis()` | source fix | `agentrx/judge/judge.py` |
| `test(invariants): fence static-invariant wildcard + matcher contract` | tests | `tests/test_static_invariant_wildcard.py` |
| `test(judge): fence analysis() no-stale-reuse contract` | tests | `tests/test_judge_analysis_no_stale_reuse.py` |

Neither fix touches runtime/checker/IR logic, adds dependencies, or changes any
public signature or flag.

---

## Bug 1 — Static (global) invariants never fire

**File:** `agentrx/invariants/static_invariant_generator.py` (prompt content only)

### Symptom
Every static/global invariant produced by `StaticInvariantGenerator` is silently
dropped at match time. On the tau-bench split (29 trajectories) **271/271
generated static invariants were inert** — checker telemetry showed firings only
from dynamic invariants, never static.

### Root cause
Static/global invariants must carry `event_trigger.step_index = "*"` (the
wildcard meaning *check at every step*). The runtime matcher
(`AllVerifier._step_matches_trigger`) compares the trigger against each step's
**1-indexed** `index`. The released prompt only documented the wildcard inside a
decorative JSON comment:

```jsonc
"step_index": "*|int|range",  // IMPORTANT: Use "*" for invariants that should be checked at EVERY step.
```

LLMs treat that comment as filler and fall back to emitting the integer `0`.
Because trajectory steps start at index `1`, a trigger of `0` matches **no real
step**, so the invariant never fires. (Empirically: 210 invariants emitted `0`,
51 emitted `1`, 10 emitted `2`, and `0` emitted `"*"`.)

### Fix (prompt-only)
Port the worked-example pattern that reliably produces `"*"`:
1. Replace the decorative declaration in both prompt templates
   (`STATIC_INVARIANT_PROMPT_PYTHON_ONLY` and `STATIC_INVARIANT_PROMPT`) with the
   literal `"step_index": "*"` plus explicit wording that `0/1/2` must never be
   used as a stand-in for "every step".
2. Add a **COMPLETE INVARIANT EXAMPLE** block after each schema that inlines the
   literal `"step_index": "*"` — LLMs reliably copy worked JSON examples even when
   they ignore comments.

No runtime/checker/IR code is changed. (Note: invariant artifacts generated
*before* this change remain inert and would need regeneration to benefit; this
change only affects future generations.)

---

## Bug 2 — `analysis()` reuses stale on-disk results

**File:** `agentrx/judge/judge.py` (function `analysis()`)

### Symptom
A judge run can write a `runN.json` whose `summary` and `detailed_results`
**describe different runs**, or can overwrite a complete result set with a stale
partial one.

### Root cause
The file-writing block in `analysis()` started by reading back whatever already
existed at `output_file_path` and using *that* as the `detailed_results` it would
re-emit:

```python
if os.path.exists(output_file_path):
    with open(output_file_path, 'r') as f:
        existing_data = json.load(f)
    if isinstance(existing_data, dict) and "detailed_results" in existing_data:
        existing_data = existing_data["detailed_results"]
    if not isinstance(existing_data, list):
        existing_data = data
else:
    existing_data = data
```

This "read-back then rewrite" is a pure data-loss vector in three real scenarios:
1. **AAD-interrupted prior write** — a partial `runN.json` is promoted over the
   current run's complete results.
2. **Sibling stages dropping skeletons** — a placeholder JSON seeded by an
   earlier stage is promoted to canonical `detailed_results`.
3. **Cross-run contamination** — a re-run/sweep rewriting `runN.json` pairs the
   current `summary` with a *previous* run's `detailed_results`, silently
   producing a self-inconsistent artifact.

### Fix
`data` (the freshly computed per-task reports passed in by the caller) is the
single source of truth. The whole read-back block collapses to:

```python
existing_data = data
```

Every `runN.json` is now guaranteed self-consistent, and downstream readers
(`extract_metrics_from_json` / `create_aggregate_summary`) operate on trustworthy
inputs.

---

## Tests

**13 new tests across 2 files; full suite on this branch: 26 passed.**
All tests are deterministic and require no LLM/network access.

### `tests/test_static_invariant_wildcard.py` (11 tests)

*Regression guard for the prompt fix* — `TestStaticPromptEmitsWildcard`
(parametrized over both prompt templates):
- `test_prompt_specifies_literal_wildcard` — each template contains the literal
  `"step_index": "*"`.
- `test_prompt_has_worked_example` — each template carries a
  `COMPLETE INVARIANT EXAMPLE` block (the mechanism the LLM actually copies).
- `test_prompt_drops_decorative_declaration` — the pre-fix `"*|int|range"` and
  bare `"step_index": "int"` declarations are gone.
- `test_prompt_warns_against_integer_stand_in` — the explicit "Never use 0, 1, 2"
  guidance is present.

*Runtime-contract documentation* — `TestMatcherDropsIntegerStepIndex` pins the
behavior that makes the wildcard necessary, by exercising
`AllVerifier._step_matches_trigger` directly (built via `__new__`, since the
method uses no instance state):
- `test_wildcard_matches_every_step` — `"*"` matches steps with index 1, 2, 3.
- `test_integer_zero_never_matches_one_indexed_trajectory` — integer `0` matches
  **none** of a 1-indexed trajectory (the exact defect).
- `test_specific_integer_matches_only_its_own_step` — a concrete int matches only
  the step whose `index` equals it.

> I verified the regression guard is real: on the current unfixed `main`, the
> prompt file contains **0** `COMPLETE INVARIANT EXAMPLE` blocks and **1**
> `"*|int|range"` declaration, so the prompt-content tests fail pre-fix and pass
> post-fix.

### `tests/test_judge_analysis_no_stale_reuse.py` (2 tests)

- `test_analysis_overwrites_stale_detailed_results` — seeds a **bogus**
  pre-existing `run1.json`, calls `analysis()` with fresh data, and asserts the
  written `detailed_results` reflect only the fresh tasks (the `BOGUS` record does
  not bleed through) and that the summary counts/token totals come from the fresh
  data.
- `test_analysis_writes_when_file_absent` — `analysis()` writes correctly when no
  prior file exists (including parent-dir handling).

### Coverage notes for reviewers
- **Bug 1**: covered at both layers — the *prompt* (regression guard, fails if the
  decorative form returns) and the *matcher contract* (documents why `"*"` is
  required and that integer `0` is silently dropped). The end-to-end "LLM actually
  emits `"*"`" step is inherently non-deterministic and is therefore left to live
  runs, not unit tests.
- **Bug 2**: covered at the unit level on `analysis()`'s file-write contract; the
  three production triggers (interrupted write, skeleton, cross-run) all reduce to
  the same "stale file on disk" precondition, which the bogus-file test exercises.

---

## How to run

```bash
python -m pytest tests/test_static_invariant_wildcard.py tests/test_judge_analysis_no_stale_reuse.py -v
```

## Scope / non-goals
- These are **correctness fixes** (invariants actually fire; artifacts are
  self-consistent). They are *not* claimed to close any specific published
  benchmark gap on their own.
- No runtime/checker/IR changes, no new dependencies, no API/flag changes.
